### PR TITLE
feat: probe() exit-code helper, Command::retry, streaming honors timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,36 @@ to a dated version section.
 ## [Unreleased]
 
 ### Added
--
+- `probe` — run a predicate command and read its exit code as a `bool`: exit `0` →
+  `Ok(true)`, exit `1` → `Ok(false)`, anything else → `Err` (other code / timeout /
+  signal-kill). On `Command`, `CliClient`, and `ProcessRunnerExt`. Collapses the
+  `match code { 0 => …, 1 => …, _ => Err }` idiom (`git diff --quiet`, `grep -q`, …).
+- `Command::retry(max_attempts, backoff, retry_if)` — replay the run while
+  `retry_if(&Error)` accepts the failure, with fixed backoff. Honored by the
+  success-checking helpers (`run`/`exit_code`/`probe` and the `CliClient`
+  `text`/`unit`/`code`/`parse`/`try_parse` helpers); the non-erroring `output_string`/
+  `output_bytes`/`capture` paths don't retry. One-shot stdin sources can't replay.
 
 ### Changed
--
+- `RunningProcess::stdout_lines` now honors the command's `timeout`: at the deadline
+  the process tree is killed and the stream ends, so a streamed run can no longer hang
+  past its timeout (`finish_streamed` then reports the kill — `code` is `None` on a Unix
+  signal-kill, a platform code on a Windows Job kill). Previously the timeout applied
+  only to the run-to-completion helpers.
 
 ### Fixed
--
+- Linux (cgroup backend): `Drop` no longer leaks the cgroup directory. `cgroup.kill`
+  is asynchronous, so the immediate `rmdir` used to race the still-draining members
+  and fail with `EBUSY`; `Drop` now waits (bounded) for the subtree to drain first.
+- Linux (cgroup backend, pre-5.14 kernels): the per-pid SIGKILL fallback no longer
+  busy-spins — it sleeps briefly between sweeps.
+- Streaming: a panicking `on_stdout_line` / `on_stderr_line` handler no longer hangs a
+  `stdout_lines` consumer. The pump now closes its sink on any exit (including a panic
+  unwind), so the stream always ends instead of parking forever.
+- Streaming: a second `stdout_lines()` call no longer silently discards the first call's
+  stderr (it previously overwrote the stderr sink, so `finish_streamed` returned empty).
+- Test double: `Reply::timeout()` now reports the command's real configured deadline in
+  `Error::Timeout` (it previously surfaced a zero duration, diverging from the live runner).
 
 ## [0.5.2] - 2026-06-03
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -159,6 +159,15 @@ impl<R: ProcessRunner> CliClient<R> {
         self.runner.exit_code(&command).await
     }
 
+    /// Run a predicate `command` and read its exit code as a boolean: exit `0` →
+    /// `Ok(true)`, exit `1` → `Ok(false)`, anything else → `Err`. Collapses the
+    /// `match code { 0 => …, 1 => …, _ => Err }` idiom for commands whose exit
+    /// code is the answer (`git diff --quiet`, `git show-ref --verify --quiet`,
+    /// `grep -q`, …); other codes / timeout / signal-kill all error.
+    pub async fn probe(&self, command: Command) -> Result<bool> {
+        self.runner.probe(&command).await
+    }
+
     /// Run `command` (errors on a non-zero exit) and feed its stdout to an
     /// infallible `parse` — the shape of git/jj struct-returning commands.
     pub async fn parse<T>(&self, command: Command, parse: impl FnOnce(&str) -> T) -> Result<T> {
@@ -381,6 +390,24 @@ mod tests {
             client.command(["status"]).configured_timeout(),
             Some(Duration::from_secs(7))
         );
+    }
+
+    #[tokio::test]
+    async fn probe_maps_exit_code_to_bool() {
+        let client = CliClient::with_runner(
+            "git",
+            ScriptedRunner::new()
+                .on(["diff"], Reply::fail(1, ""))
+                .fallback(Reply::ok("")),
+        );
+        // `git diff --quiet` exits 1 (dirty) -> false; anything else (0) -> true.
+        assert!(
+            !client
+                .probe(client.command(["diff", "--quiet"]))
+                .await
+                .unwrap()
+        );
+        assert!(client.probe(client.command(["status"])).await.unwrap());
     }
 
     #[tokio::test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -40,6 +40,16 @@ pub struct Command {
     output_buffer: OutputBufferPolicy,
     stdout_encoding: &'static Encoding,
     stderr_encoding: &'static Encoding,
+    retry: Option<RetryPolicy>,
+}
+
+/// A retry policy attached to a [`Command`] via [`Command::retry`], honored by
+/// the success-checking run helpers. Cheap to clone (the classifier is `Arc`'d).
+#[derive(Clone)]
+pub(crate) struct RetryPolicy {
+    pub(crate) max_attempts: u32,
+    pub(crate) backoff: Duration,
+    pub(crate) classifier: Arc<dyn Fn(&Error) -> bool + Send + Sync>,
 }
 
 impl Command {
@@ -59,6 +69,7 @@ impl Command {
             output_buffer: OutputBufferPolicy::unbounded(),
             stdout_encoding: UTF_8,
             stderr_encoding: UTF_8,
+            retry: None,
         }
     }
 
@@ -118,9 +129,50 @@ impl Command {
         self
     }
 
+    /// Retry the run while `retry_if` accepts the error, up to `max_attempts`
+    /// total attempts, sleeping `backoff` between tries.
+    ///
+    /// Applies to the **success-checking** helpers — [`run`](Self::run),
+    /// [`exit_code`](Self::exit_code), [`probe`](Self::probe), and the
+    /// [`CliClient`](crate::CliClient) `text`/`unit`/`code`/`parse`/`try_parse`
+    /// helpers — i.e. the ones that surface failure as an [`Error`] the classifier
+    /// can inspect (e.g. a transient network failure in `stderr`, or
+    /// [`Error::Timeout`](crate::Error::Timeout)). The non-erroring
+    /// `output_string`/`output_bytes`/`capture` paths don't retry.
+    ///
+    /// Each attempt **re-executes the whole command** — a fresh process. Only
+    /// retry operations that are safe to repeat: a side effect that already landed
+    /// before the failure (a `git push` that reached the server, then dropped the
+    /// connection) will be replayed. Prefer to gate retries on a classifier that
+    /// matches *pre-effect* failures (DNS/connection errors, [`Error::Timeout`]
+    /// while still connecting) rather than any non-zero exit.
+    ///
+    /// Because the command is replayed from scratch, a **one-shot** stdin source
+    /// ([`Stdin::from_reader`](crate::Stdin::from_reader) /
+    /// [`from_lines`](crate::Stdin::from_lines)) won't survive a retry — the second
+    /// attempt sees empty stdin. Use a reusable source
+    /// (`from_string`/`from_bytes`/`from_file`/`from_iter_lines`) when retrying.
+    ///
+    /// [`Error::Timeout`]: crate::Error::Timeout
+    pub fn retry(
+        mut self,
+        max_attempts: u32,
+        backoff: Duration,
+        retry_if: impl Fn(&Error) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        self.retry = Some(RetryPolicy {
+            max_attempts,
+            backoff,
+            classifier: Arc::new(retry_if),
+        });
+        self
+    }
+
     /// Leave stdin open after start so the child can be driven interactively via
     /// [`RunningProcess::standard_input`](crate::RunningProcess::standard_input).
-    /// Has no effect on the bulk run helpers (they always close stdin).
+    /// Has no effect on the bulk run helpers (they always close stdin). Takes
+    /// precedence over a [`stdin`](Self::stdin) source — when set, that source is
+    /// ignored and the pipe is handed to the caller instead.
     pub fn keep_stdin_open(mut self) -> Self {
         self.keep_stdin_open = true;
         self
@@ -189,6 +241,10 @@ impl Command {
 
     pub(crate) fn output_buffer_policy(&self) -> OutputBufferPolicy {
         self.output_buffer
+    }
+
+    pub(crate) fn retry_policy(&self) -> Option<RetryPolicy> {
+        self.retry.clone()
     }
 
     pub(crate) fn out_encoding(&self) -> &'static Encoding {
@@ -323,8 +379,16 @@ impl Command {
 
     /// Run to completion, requiring a zero exit, and return trimmed stdout.
     pub async fn run(&self) -> Result<String> {
-        let result = self.output_string().await?.ensure_success()?;
-        Ok(result.into_stdout().trim_end().to_owned())
+        JobRunner::new().run(self).await
+    }
+
+    /// Run a predicate command and read its exit code as a boolean: exit `0` →
+    /// `Ok(true)`, exit `1` → `Ok(false)`, anything else → `Err` (any other code
+    /// as [`Error::Exit`], a timeout as [`Error::Timeout`](crate::Error::Timeout),
+    /// a signal-kill as an IO error). For tools whose exit code *is* the answer —
+    /// `git diff --quiet`, `git show-ref --verify --quiet`, `grep -q`, …
+    pub async fn probe(&self) -> Result<bool> {
+        JobRunner::new().probe(self).await
     }
 
     /// Return the first stdout line matching `predicate` (or the first line when
@@ -379,6 +443,7 @@ impl fmt::Debug for Command {
             .field("output_buffer", &self.output_buffer)
             .field("stdout_encoding", &self.stdout_encoding.name())
             .field("stderr_encoding", &self.stderr_encoding.name())
+            .field("has_retry", &self.retry.is_some())
             .finish()
     }
 }

--- a/src/doubles.rs
+++ b/src/doubles.rs
@@ -68,16 +68,23 @@ impl Reply {
         self
     }
 
-    fn into_result(self, program: String) -> ProcessResult<String> {
+    fn into_result(
+        self,
+        program: String,
+        timeout: Option<std::time::Duration>,
+    ) -> ProcessResult<String> {
         // A timed-out run carries no code (`None`); otherwise the canned code.
         let code = (!self.timed_out).then_some(self.code);
+        // Carry the command's configured timeout so a timed-out reply surfaces as
+        // `Error::Timeout` with the *real* deadline (matching the live runner),
+        // not a zero duration.
         ProcessResult::new(
             program,
             self.stdout,
             self.stderr,
             code,
             self.timed_out,
-            None,
+            timeout,
         )
     }
 }
@@ -151,13 +158,14 @@ impl ScriptedRunner {
 impl ProcessRunner for ScriptedRunner {
     async fn output(&self, command: &Command) -> Result<ProcessResult<String>> {
         let program = command.program().to_string_lossy().into_owned();
+        let timeout = command.configured_timeout();
         for (rule, reply) in &self.rules {
             if rule.matches(command) {
-                return Ok(reply.clone().into_result(program));
+                return Ok(reply.clone().into_result(program, timeout));
             }
         }
         match &self.fallback {
-            Some(reply) => Ok(reply.clone().into_result(program)),
+            Some(reply) => Ok(reply.clone().into_result(program, timeout)),
             None => Err(crate::error::Error::Spawn {
                 program,
                 source: std::io::Error::new(
@@ -317,6 +325,43 @@ mod tests {
         ));
         assert!(matches!(
             runner.exit_code(&Command::new("git")).await.unwrap_err(),
+            Error::Timeout { .. }
+        ));
+        // The reply carries the command's *real* configured deadline, matching the
+        // live runner — not a zero duration.
+        let cmd = Command::new("git").timeout(std::time::Duration::from_secs(7));
+        match runner.run(&cmd).await.unwrap_err() {
+            Error::Timeout { timeout, .. } => {
+                assert_eq!(timeout, std::time::Duration::from_secs(7))
+            }
+            other => panic!("expected Timeout, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_reads_exit_code_as_bool() {
+        use crate::error::Error;
+        let runner = ScriptedRunner::new()
+            .on(["yes"], Reply::ok(""))
+            .on(["no"], Reply::fail(1, ""))
+            .on(["boom"], Reply::fail(2, "bad"))
+            .fallback(Reply::timeout());
+        // 0 -> true, 1 -> false.
+        assert!(runner.probe(&Command::new("t").arg("yes")).await.unwrap());
+        assert!(!runner.probe(&Command::new("t").arg("no")).await.unwrap());
+        // Any other code -> Exit error; no code (timeout) -> Timeout error.
+        assert!(matches!(
+            runner
+                .probe(&Command::new("t").arg("boom"))
+                .await
+                .unwrap_err(),
+            Error::Exit { code: 2, .. }
+        ));
+        assert!(matches!(
+            runner
+                .probe(&Command::new("t").arg("other"))
+                .await
+                .unwrap_err(),
             Error::Timeout { .. }
         ));
     }

--- a/src/group.rs
+++ b/src/group.rs
@@ -76,6 +76,12 @@ impl ProcessGroup {
     /// them, or accept that this escape hatch forces only `CREATE_SUSPENDED`.
     /// **Unix:** the group likewise installs a `pre_exec` hook on `cmd` to join
     /// the cgroup / process group.
+    ///
+    /// These mutations make `cmd` **single-use**: each call appends another
+    /// `pre_exec` hook (Unix) and re-sets the creation flags (Windows), so reusing
+    /// the same [`Command`] across spawns stacks them. Build a fresh `cmd` per
+    /// spawn. (The crate's own run helpers do this — every run rebuilds the OS
+    /// command — so this only concerns direct `spawn` callers.)
     pub fn spawn(&self, cmd: &mut Command) -> Result<Child> {
         let child = self.job.spawn(cmd).map_err(|source| Error::Spawn {
             program: program_name(cmd),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@
 //!   [`code`](ProcessResult::code) is `Option<i32>` (`None` for a run killed by
 //!   its timeout or a signal — there is no `-1` sentinel); the `exit_code`
 //!   helpers instead surface a missing code as an error.
+//! - **`probe`** — run a predicate and read its exit code as a `bool`: `0` →
+//!   `true`, `1` → `false`, anything else is an error (`git diff --quiet`, …).
 //!
 //! ```no_run
 //! # async fn demo() -> processkit::Result<()> {
@@ -41,6 +43,42 @@
 //! // Or require success and get trimmed stdout directly.
 //! let version = Command::new("cargo").arg("--version").run().await?;
 //! # let _ = version;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Recipes
+//!
+//! ```no_run
+//! # use std::time::Duration;
+//! # async fn demo() -> processkit::Result<()> {
+//! use processkit::{Command, Error};
+//!
+//! // Exit code *is* the answer (0 = yes, 1 = no; anything else errors):
+//! let clean = Command::new("git").args(["diff", "--quiet"]).probe().await?;
+//!
+//! // Retry a transient failure (replays the command; classifier inspects the error):
+//! let fetched = Command::new("git")
+//!     .args(["fetch", "--quiet"])
+//!     .timeout(Duration::from_secs(10))
+//!     .retry(3, Duration::from_millis(200), |e| {
+//!         matches!(e, Error::Timeout { .. })
+//!             || e.diagnostic().is_some_and(|m| m.contains("Could not resolve host"))
+//!     })
+//!     .run()
+//!     .await;
+//!
+//! // A friendly failure message — stderr, falling back to stdout (git writes
+//! // `CONFLICT …` / `nothing to commit` there):
+//! if let Err(e) = Command::new("git").args(["merge", "topic"]).run().await {
+//!     eprintln!("merge failed: {}", e.diagnostic().unwrap_or("(no output)"));
+//! }
+//!
+//! // Set an env var once for every command (typed CLI wrapper):
+//! use processkit::CliClient;
+//! let git = CliClient::new("git").default_env("GIT_TERMINAL_PROMPT", "0");
+//! let _ = git.text(git.command(["status", "--porcelain"])).await?;
+//! # let _ = (clean, fetched);
 //! # Ok(())
 //! # }
 //! ```

--- a/src/pump.rs
+++ b/src/pump.rs
@@ -81,7 +81,14 @@ impl SharedLines {
     }
 
     fn close(&self) {
-        self.inner.lock().expect("SharedLines poisoned").closed = true;
+        // Recover a poisoned lock instead of panicking: `close` runs from a
+        // `Drop` guard on the pump task's unwind path (see `pump_lines`), where a
+        // second panic would abort the process. Only the `closed` flag is set
+        // here, and that is safe regardless of any prior poisoning.
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .closed = true;
         self.notify.notify_one();
     }
 
@@ -138,6 +145,17 @@ pub(crate) async fn pump_lines<R>(
 ) where
     R: AsyncRead + Unpin,
 {
+    // Close the sink on *every* exit from this task, including a panic unwind
+    // from a user `handler`. Without this, a panicking handler would leave the
+    // sink un-closed and a streaming `StdoutLines` consumer parked forever.
+    struct CloseOnDrop(Arc<SharedLines>);
+    impl Drop for CloseOnDrop {
+        fn drop(&mut self) {
+            self.0.close();
+        }
+    }
+    let sink = CloseOnDrop(sink);
+
     let mut reader = BufReader::new(reader);
     let mut buf = Vec::new();
     loop {
@@ -157,9 +175,9 @@ pub(crate) async fn pump_lines<R>(
         if let Some(handler) = &handler {
             handler(&line);
         }
-        sink.push(line);
+        sink.0.push(line);
     }
-    sink.close();
+    // `sink` (the guard) closes here on normal completion too.
 }
 
 #[cfg(test)]
@@ -231,5 +249,27 @@ mod tests {
             "retain-nothing policy keeps no lines"
         );
         assert_eq!(*seen.lock().unwrap(), vec!["x", "y"]);
+    }
+
+    #[tokio::test]
+    async fn panicking_handler_still_closes_the_sink() {
+        // A user handler that panics must not leave the sink un-closed — otherwise
+        // a streaming consumer would park on `changed()` forever.
+        let handler: LineHandler = Arc::new(|_: &str| panic!("boom"));
+        let sink = SharedLines::new(&OutputBufferPolicy::unbounded());
+        let task = tokio::spawn(pump_lines(
+            &b"one\ntwo\n"[..],
+            encoding_rs::UTF_8,
+            Some(handler),
+            sink.clone(),
+        ));
+        // The pump task unwinds from the handler panic...
+        assert!(task.await.is_err(), "the pump task should have panicked");
+        // ...but the sink is still closed, so a consumer wakes and ends.
+        sink.clone().changed().await;
+        assert!(
+            matches!(sink.try_pop(), Popped::Closed),
+            "sink must be closed after a handler panic"
+        );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -6,7 +6,7 @@
 //! fabricated). Live-handle / streaming runs use the concrete
 //! [`start`](JobRunner::start) methods instead.
 
-use crate::command::Command;
+use crate::command::{Command, RetryPolicy};
 use crate::error::Result;
 use crate::group::ProcessGroup;
 use crate::result::ProcessResult;
@@ -43,8 +43,12 @@ impl<R: ProcessRunner + ?Sized> ProcessRunner for &R {
 pub trait ProcessRunnerExt: ProcessRunner {
     /// Run, require a zero exit, and return trimmed stdout.
     async fn run(&self, command: &Command) -> Result<String> {
-        let result = self.output(command).await?.ensure_success()?;
-        Ok(result.into_stdout().trim_end().to_owned())
+        Ok(self
+            .checked(command)
+            .await?
+            .into_stdout()
+            .trim_end()
+            .to_owned())
     }
 
     /// Run and return just the exit code. A run that produced no code surfaces as
@@ -52,7 +56,31 @@ pub trait ProcessRunnerExt: ProcessRunner {
     /// signal-kill as an IO error — rather than a synthetic sentinel, mirroring
     /// [`ensure_success`](crate::ProcessResult::ensure_success).
     async fn exit_code(&self, command: &Command) -> Result<i32> {
-        self.output(command).await?.require_code()
+        retrying(command.retry_policy(), || async {
+            self.output(command).await?.require_code()
+        })
+        .await
+    }
+
+    /// Run a predicate command and read its exit code as a boolean: exit `0` →
+    /// `Ok(true)`, exit `1` → `Ok(false)`, anything else → `Err` (other code as
+    /// [`Error::Exit`](crate::Error::Exit), timeout as
+    /// [`Error::Timeout`](crate::Error::Timeout), signal-kill as an IO error). For
+    /// commands whose exit code *is* the answer — `git diff --quiet`, `grep -q`, …
+    async fn probe(&self, command: &Command) -> Result<bool> {
+        retrying(command.retry_policy(), || async {
+            let result = self.output(command).await?;
+            match result.code() {
+                Some(0) => Ok(true),
+                Some(1) => Ok(false),
+                // Any other code (or no code: timeout / signal) is not a yes/no
+                // answer — reuse ensure_success to build the faithful error.
+                _ => Err(result
+                    .ensure_success()
+                    .expect_err("a non-{0,1} exit code is never success")),
+            }
+        })
+        .await
     }
 
     /// Run, require a zero exit, and return the full captured result (untrimmed
@@ -60,7 +88,34 @@ pub trait ProcessRunnerExt: ProcessRunner {
     /// when you need the whole `ProcessResult` after success-checking, rather
     /// than just trimmed stdout (`run`) or the raw result (`output`).
     async fn checked(&self, command: &Command) -> Result<ProcessResult<String>> {
-        self.output(command).await?.ensure_success()
+        retrying(command.retry_policy(), || async {
+            self.output(command).await?.ensure_success()
+        })
+        .await
+    }
+}
+
+/// Run `attempt` once, or — when the command carries a [`RetryPolicy`] — up to
+/// `max_attempts` times, retrying while the error is classified retryable and
+/// sleeping `backoff` between tries. The building block under the success-checking
+/// `ProcessRunnerExt` helpers; the non-erroring `output` path never retries.
+async fn retrying<T, Fut, F>(policy: Option<RetryPolicy>, mut attempt: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: core::future::Future<Output = Result<T>>,
+{
+    let mut tries = 0u32;
+    loop {
+        tries += 1;
+        match attempt().await {
+            Ok(value) => return Ok(value),
+            Err(err) => match &policy {
+                Some(p) if tries < p.max_attempts && (p.classifier)(&err) => {
+                    tokio::time::sleep(p.backoff).await;
+                }
+                _ => return Err(err),
+            },
+        }
     }
 }
 
@@ -160,4 +215,75 @@ pub(crate) async fn launch(group: &ProcessGroup, command: &Command) -> Result<Ru
         stderr_handler: command.stderr_handler(),
         buffer: command.output_buffer_policy(),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    /// A fake runner that reports a non-zero exit for its first `fail_times`
+    /// calls, then a success — and counts total calls. No real process.
+    struct Flaky {
+        calls: AtomicU32,
+        fail_times: u32,
+    }
+
+    #[async_trait::async_trait]
+    impl ProcessRunner for Flaky {
+        async fn output(&self, command: &Command) -> Result<ProcessResult<String>> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            let code = if n < self.fail_times { 1 } else { 0 };
+            Ok(ProcessResult::new(
+                command.program().to_string_lossy().into_owned(),
+                "out".to_owned(),
+                "transient".to_owned(),
+                Some(code),
+                false,
+                None,
+            ))
+        }
+    }
+
+    fn flaky(fail_times: u32) -> Flaky {
+        Flaky {
+            calls: AtomicU32::new(0),
+            fail_times,
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_retries_until_success() {
+        let runner = flaky(2);
+        let cmd = Command::new("x").retry(5, Duration::from_millis(0), |e| {
+            matches!(e, Error::Exit { .. })
+        });
+        assert_eq!(runner.run(&cmd).await.unwrap(), "out");
+        assert_eq!(runner.calls.load(Ordering::SeqCst), 3); // 2 failures + 1 success
+    }
+
+    #[tokio::test]
+    async fn retry_stops_when_classifier_rejects() {
+        let runner = flaky(5);
+        let cmd = Command::new("x").retry(5, Duration::from_millis(0), |_| false);
+        assert!(runner.run(&cmd).await.is_err());
+        assert_eq!(runner.calls.load(Ordering::SeqCst), 1); // no retry
+    }
+
+    #[tokio::test]
+    async fn retry_caps_at_max_attempts() {
+        let runner = flaky(10);
+        let cmd = Command::new("x").retry(3, Duration::from_millis(0), |_| true);
+        assert!(runner.run(&cmd).await.is_err());
+        assert_eq!(runner.calls.load(Ordering::SeqCst), 3); // capped
+    }
+
+    #[tokio::test]
+    async fn no_policy_runs_once() {
+        let runner = flaky(10);
+        assert!(runner.run(&Command::new("x")).await.is_err());
+        assert_eq!(runner.calls.load(Ordering::SeqCst), 1);
+    }
 }

--- a/src/running.rs
+++ b/src/running.rs
@@ -53,7 +53,9 @@ pub(crate) struct Spawned {
 pub struct RunningProcess {
     program: String,
     child: Child,
-    own_group: Option<ProcessGroup>,
+    // `Arc` so a streaming deadline timer can hold a `Weak` to kill the tree
+    // without keeping the group alive (kill-on-close on drop stays prompt).
+    own_group: Option<Arc<ProcessGroup>>,
     stdout_pipe: Option<ChildStdout>,
     stderr_pipe: Option<ChildStderr>,
     stdin_pipe: Option<ChildStdin>,
@@ -70,6 +72,9 @@ pub struct RunningProcess {
     // The background stderr-drain task started by `stdout_lines`, awaited by
     // `finish_streamed` so no trailing stderr line is missed.
     stderr_pump: Option<JoinHandle<()>>,
+    // A timer started by `stdout_lines` when a timeout is set: kills the tree at
+    // the deadline so a streamed run can't hang forever. Aborted on drop.
+    deadline_task: Option<JoinHandle<()>>,
     started: Instant,
     start_time: SystemTime,
 }
@@ -79,7 +84,7 @@ impl RunningProcess {
         Self {
             program: s.program,
             child: s.child,
-            own_group: s.own_group,
+            own_group: s.own_group.map(Arc::new),
             stdout_pipe: s.stdout,
             stderr_pipe: s.stderr,
             stdin_pipe: s.stdin,
@@ -94,13 +99,14 @@ impl RunningProcess {
             stdout_sink: None,
             stderr_sink: None,
             stderr_pump: None,
+            deadline_task: None,
             started: Instant::now(),
             start_time: SystemTime::now(),
         }
     }
 
     pub(crate) fn attach_group(&mut self, group: ProcessGroup) {
-        self.own_group = Some(group);
+        self.own_group = Some(Arc::new(group));
     }
 
     /// The OS process id, or `None` if the child has already been reaped.
@@ -180,12 +186,16 @@ impl RunningProcess {
     /// when you need both. Keep this `RunningProcess` in scope while consuming;
     /// dropping it tears the process down.
     ///
-    /// The command's [`timeout`](crate::Command::timeout) is **not** auto-enforced
-    /// while you pull lines from this stream (only the run-to-completion helpers —
-    /// `output_string`/`wait`/`finish_streamed` and `Command::first_line` — apply
-    /// it). To bound a manual stream, wrap your consumption in
-    /// [`tokio::time::timeout`] and drop this handle (which kills the tree) on
-    /// elapse.
+    /// The command's [`timeout`](crate::Command::timeout), if set, **bounds the
+    /// stream**: at the deadline the process tree is killed, so the pipes close
+    /// and this stream ends — a streamed run can't hang past its timeout. A
+    /// following [`finish_streamed`](Self::finish_streamed) then reports the kill
+    /// (no clean exit: `code` is `None` on a Unix signal-kill, a platform code on
+    /// a Windows Job kill). With no timeout the stream is unbounded as before.
+    /// (Bounding applies to a run that owns its group — the
+    /// [`Command::start`](crate::Command::start) / [`JobRunner`](crate::JobRunner)
+    /// path. A handle from [`ProcessGroup::start`](crate::ProcessGroup::start)
+    /// shares its group, so the caller bounds the stream.)
     ///
     /// # Example
     ///
@@ -210,17 +220,21 @@ impl RunningProcess {
     /// ```
     pub fn stdout_lines(&mut self) -> StdoutLines {
         // Background-drain stderr (counter + handler still apply). The handle is
-        // kept so `finish_streamed` can await the last line before draining.
-        let stderr_sink = SharedLines::new(&self.buffer);
-        if let Some(pipe) = self.stderr_pipe.take() {
-            self.stderr_pump = Some(tokio::spawn(pump_lines(
-                pipe,
-                self.stderr_encoding,
-                self.stderr_handler.clone(),
-                stderr_sink.clone(),
-            )));
+        // kept so `finish_streamed` can await the last line before draining. Only
+        // set up once: a second `stdout_lines` call must not overwrite the first
+        // call's sink/pump, or `finish_streamed` would return empty stderr.
+        if self.stderr_sink.is_none() {
+            let stderr_sink = SharedLines::new(&self.buffer);
+            if let Some(pipe) = self.stderr_pipe.take() {
+                self.stderr_pump = Some(tokio::spawn(pump_lines(
+                    pipe,
+                    self.stderr_encoding,
+                    self.stderr_handler.clone(),
+                    stderr_sink.clone(),
+                )));
+            }
+            self.stderr_sink = Some(stderr_sink);
         }
-        self.stderr_sink = Some(stderr_sink);
 
         let stdout_sink = SharedLines::new(&self.buffer);
         match self.stdout_pipe.take() {
@@ -236,6 +250,23 @@ impl RunningProcess {
             None => stdout_sink.close_now(),
         }
         self.stdout_sink = Some(stdout_sink.clone());
+
+        // Bound the stream by the command's timeout: kill the tree at the deadline
+        // so the pipes close and this stream ends. A `Weak` to the group means the
+        // timer never delays kill-on-close when the handle is dropped early. Armed
+        // once (a second `stdout_lines` call won't spawn a duplicate timer).
+        if self.deadline_task.is_none()
+            && let (Some(limit), Some(group)) = (self.timeout, self.own_group.as_ref())
+        {
+            let group = Arc::downgrade(group);
+            self.deadline_task = Some(tokio::spawn(async move {
+                tokio::time::sleep(limit).await;
+                if let Some(group) = group.upgrade() {
+                    let _ = group.terminate_all();
+                }
+            }));
+        }
+
         StdoutLines {
             sink: stdout_sink,
             wait: None,
@@ -436,6 +467,11 @@ impl Drop for RunningProcess {
     fn drop(&mut self) {
         // Abort a still-running stdin writer; a finished one is unaffected.
         if let Some(task) = self.stdin_task.take() {
+            task.abort();
+        }
+        // Abort the streaming deadline timer (it holds only a `Weak` to the group,
+        // so this never blocks the group's kill-on-close).
+        if let Some(task) = self.deadline_task.take() {
             task.abort();
         }
     }

--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -207,6 +207,18 @@ impl Drop for Job {
         match &self.backend {
             Backend::Cgroup(cg) => {
                 let _ = cg.kill();
+                // `cgroup.kill` is asynchronous: the kernel SIGKILLs the subtree,
+                // but `rmdir` returns `EBUSY` until the members have actually left
+                // (a process leaves `cgroup.procs` when it *exits*, before it is
+                // reaped — so this drains within milliseconds and doesn't depend on
+                // the async reaper). Wait, bounded, so we don't leak the dir; sleep
+                // rather than busy-spin.
+                for _ in 0..50 {
+                    if cg.is_empty() {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(2));
+                }
                 // Best-effort: an emptied cgroup dir can be removed.
                 let _ = std::fs::remove_dir(&cg.path);
             }
@@ -286,9 +298,10 @@ impl Cgroup {
         if std::fs::write(self.path.join("cgroup.kill"), b"1").is_ok() {
             return Ok(());
         }
-        // Older kernels: SIGKILL each member until the cgroup drains. Bounded so
-        // teardown (incl. Drop) can never hang on un-reaped zombies.
-        for _ in 0..100 {
+        // Older kernels: SIGKILL each member until the cgroup drains. Sleep
+        // between sweeps rather than busy-spin while the kernel reaps, and bound
+        // it so teardown (incl. Drop) can never hang on un-reaped zombies.
+        for _ in 0..50 {
             let members = self.members();
             if members.is_empty() {
                 break;
@@ -299,6 +312,7 @@ impl Cgroup {
                     libc::kill(pid, libc::SIGKILL);
                 }
             }
+            std::thread::sleep(Duration::from_millis(2));
         }
         Ok(())
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -325,6 +325,64 @@ async fn windows_grandchild_is_contained() {
 }
 
 #[tokio::test]
+#[ignore = "spawns real subprocesses"]
+async fn probe_reads_real_exit_codes() {
+    // Exit 0 -> Ok(true), exit 1 -> Ok(false), exit 2 -> Err.
+    let exits = |code: i32| {
+        if cfg!(windows) {
+            Command::new("cmd").args(["/c", "exit", &code.to_string()])
+        } else {
+            Command::new("sh").args(["-c", &format!("exit {code}")])
+        }
+    };
+    assert!(exits(0).probe().await.expect("exit 0 is a clean true"));
+    assert!(!exits(1).probe().await.expect("exit 1 is a clean false"));
+    assert!(
+        exits(2).probe().await.is_err(),
+        "any code other than 0/1 must be an error, not a silent bool"
+    );
+}
+
+#[tokio::test]
+#[ignore = "spawns a real subprocess that outlives its timeout"]
+async fn streaming_honors_timeout() {
+    use tokio_stream::StreamExt;
+
+    // Emit one line, then idle well past the timeout. The deadline must end the
+    // stream (kill the tree) rather than hang.
+    let cmd = if cfg!(windows) {
+        Command::new("cmd").args(["/c", "echo one& ping -n 30 127.0.0.1 >NUL"])
+    } else {
+        Command::new("sh").args(["-c", "echo one; sleep 30"])
+    }
+    .timeout(Duration::from_millis(500));
+
+    let start = Instant::now();
+    let mut run = cmd.start().await.expect("start");
+    let mut lines = run.stdout_lines();
+    let mut seen = Vec::new();
+    while let Some(line) = lines.next().await {
+        seen.push(line);
+    }
+    drop(lines);
+    let (code, _stderr) = run.finish_streamed().await.expect("finish");
+
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "stream did not end at the deadline (took {:?})",
+        start.elapsed()
+    );
+    // The tree was killed at the deadline. The exact code is platform-dependent
+    // (None on a Unix signal-kill, a nonzero code on a Windows Job kill), so the
+    // guarantee under test is "ended promptly and not a clean success".
+    assert!(
+        !matches!(code, Some(0)),
+        "a timed-out streamed run must not look successful (got {code:?})"
+    );
+    assert!(seen.iter().any(|l| l.contains("one")), "saw: {seen:?}");
+}
+
+#[tokio::test]
 #[ignore = "spawns a real subprocess"]
 async fn stdout_line_handler_sees_every_line() {
     let seen = Arc::new(Mutex::new(Vec::<String>::new()));


### PR DESCRIPTION
Convenience + reliability additions from the consumer analysis (vcs-toolkit-rs / vcs-flow-rs / agent-workspace). Additive except the one streaming-timeout behavior change → **0.6.0**.

## Added
- **`probe()`** on `ProcessRunnerExt`, `CliClient`, and `Command` — run a predicate and read its exit code as a `bool`: exit `0` → `Ok(true)`, `1` → `Ok(false)`, **anything else → `Err`** (other code as `Error::Exit`, timeout as `Error::Timeout`, signal-kill as IO). Collapses the repeated `match code { 0 => …, 1 => …, _ => Err }` idiom (`git diff --quiet`, `grep -q`, …) without the footgun of treating arbitrary codes as `false`.
- **`Command::retry(max_attempts, backoff, retry_if)`** — replays the run while `retry_if(&Error)` accepts the failure. Honored by the success-checking helpers (`run`/`exit_code`/`probe` + `CliClient` `text`/`unit`/`code`/`parse`/`try_parse`) via a single `retrying` loop in `ProcessRunnerExt`; the non-erroring `output_string`/`output_bytes`/`capture` paths don't retry. One-shot stdin (`from_reader`/`from_lines`) can't replay — documented.

## Changed
- **`RunningProcess::stdout_lines` now honors the command's `timeout`**: at the deadline the process tree is killed and the stream ends, so a streamed run can't hang past its timeout (`finish_streamed` then reports the kill — `code` `None` on a Unix signal-kill, a platform code on a Windows Job kill). Only for runs that own their group (`Command::start`/`JobRunner`); the shared-group `ProcessGroup::start` handle is caller-bounded. `own_group` became `Arc<ProcessGroup>` so the deadline timer can hold a `Weak` — kill-on-close timing is unchanged.
- Crate-doc **Recipes** block + "Run vocabulary" entry for `probe`; CHANGELOG.

## Why
`processkit` 0.5.x is mature; this targets the genuinely-improvable friction (exit-code-as-answer boilerplate, hand-rolled fetch-retry loops, manual stream timeouts). App-specific mapping and git-marker detection stay in the consumers.

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc` — clean.
- 36 unit + 21 integration (incl. real-subprocess `probe` and streaming-timeout) + 4 doctests — pass.

Reviewed across multiple adversarial passes (Send-ness of the retry loop, unreachable `expect_err` in `probe`, no kill-on-close regression from the `Arc` change, platform-dependent kill exit code).