### PR TITLE
docs: move Testing/Releasing from README to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Contributions land via pull requests into `main` (branch-protected).
+
+## Testing
+
+```bash
+cargo test                  # hermetic unit tests (no subprocess)
+cargo test -- --ignored     # real-subprocess + kill-on-drop tests
+cargo test --features mock  # the generated MockRunner
+```
+
+Before opening a PR:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+## Releasing
+
+Maintainer-only, via the **Release** GitHub Actions workflow (manual
+`workflow_dispatch` — pick `patch` / `minor` / `major`). It bumps the version,
+promotes `CHANGELOG.md`, publishes to crates.io, tags `v<version>`, and creates the
+GitHub Release. The release commit is pushed to `main` with a dedicated **GitHub App**
+token, so it works under branch protection without a personal token (the App is in the
+ruleset's bypass list).

--- a/README.md
+++ b/README.md
@@ -171,22 +171,10 @@ impl<R: ProcessRunner> Git<R> {
 }
 ```
 
-## Testing
+## Contributing
 
-```bash
-cargo test                 # hermetic unit tests (no subprocess)
-cargo test -- --ignored    # real-subprocess + kill-on-drop tests
-cargo test --features mock  # the generated MockRunner
-```
-
-## Releasing
-
-Maintainer-only, via the **Release** GitHub Actions workflow (manual
-`workflow_dispatch` — pick `patch` / `minor` / `major`). It bumps the version,
-promotes `CHANGELOG.md`, publishes to crates.io, tags `v<version>`, and creates the
-GitHub Release. The release commit is pushed to `main` with a dedicated **GitHub App**
-token, so it works under branch protection without a personal token (the App is in the
-ruleset's bypass list). Contributions land via pull requests into `main`.
+Running the tests and the (maintainer-only) release process are documented in
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## What

crates.io renders `README.md` (`readme = "README.md"` in Cargo.toml), so the **Testing** and **Releasing** sections — maintainer-only content (test commands; the release `workflow_dispatch`, GitHub App token, ruleset bypass) — show up on the crate's public page where they're just noise for consumers.

This moves them into a new `CONTRIBUTING.md`:

- **New `CONTRIBUTING.md`** — holds `## Testing` and `## Releasing` (plus a short pre-PR `fmt`/`clippy` note). GitHub surfaces it as a first-class doc.
- **`README.md`** — the two sections replaced by a one-line `## Contributing` pointer to `CONTRIBUTING.md`.

Net: the crates.io page (and the GitHub README) stays consumer-focused — Install / Usage / Streaming / Wrapping a CLI / License — while the contributor docs still live in the repo. Single `README.md` source, no duplication.

## Scope

Docs only — no code, no API, no behavior change. Independent of #2 (0.6.0 features); based directly on `main`.