### PR TITLE
docs: add v0.6.1 changelog entry for the CONTRIBUTING.md split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ to a dated version section.
 -
 
 ### Changed
--
+- Move the Testing and Releasing guides out of `README.md` into a dedicated
+  `CONTRIBUTING.md`, keeping the README focused on usage.
 
 ### Fixed
 -


### PR DESCRIPTION
The Release workflow refused to cut a release after #2 (v0.6.0) because the only commit since the tag was the `docs:` CONTRIBUTING.md split, which `cliff.toml` deliberately skips — so `[Unreleased]` auto-fill produced nothing.

This adds a manual `[Unreleased]` entry so v0.6.1 has release-worthy notes. Manual bullets always win over git-cliff auto-fill.

After merge: run **Release** (bump `patch`) → v0.6.1.