### PR TITLE
feat: binding ergonomics for 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,43 @@ to a dated version section.
 ## [Unreleased]
 
 ### Added
--
+- `ProcessGroup::shutdown_ref(&self)` — graceful `SIGTERM` → grace → `SIGKILL`
+  teardown that **borrows** the group instead of consuming it, for a group held
+  behind a shared handle (an `Arc`, a long-lived supervisor, an FFI binding) that
+  can't be moved out by value. `shutdown(self)` now delegates to it.
+- `ProcessGroup::kill_all` — the honest name for the immediate hard kill
+  (mirrors the underlying `Job::kill_all`); replaces the misleadingly-named
+  `terminate_all`, which read as a graceful `SIGTERM`.
+- `RunProfile::outcome` — the full `Outcome` of a profiled run, plus `signal()`
+  and `timed_out()` accessors, so a profile distinguishes a clean exit from a
+  signal kill from a timeout (all three leave `exit_code` `None`). `profile()` is
+  now a superset of `wait()`: one call yields both telemetry and the outcome.
+- `RunProfile::avg_cpu_cores` — unit-explicit rename of `avg_cpu` (the value is
+  in CPU cores).
+- `RecordReplayRunner` now covers the streaming `start` verb in both record and
+  replay: a recorded run replays through a scripted `RunningProcess` (its output
+  flowing through the command's real pumps), where `start` previously returned
+  `Error::Unsupported`. Recording a `start` captures the run whole, so an
+  interactive streaming run fed stdin mid-stream still can't be cassette-recorded.
+- `CliClient` now implements `Clone` (when its runner is `Clone`, as the default
+  `JobRunner` is), so the whole CLI-wrapper family — `Command`, `Pipeline`,
+  `CliClient` — clones uniformly. A clone shares the same default cancellation
+  token.
 
 ### Changed
--
+- The readiness probes `RunningProcess::wait_for_line` / `wait_for` now require
+  `Send` callbacks (matching `Command::first_line`), so the returned futures are
+  `Send` — they can cross a thread boundary on a multi-threaded runtime or be
+  bridged onto another async runtime, not only `.await`ed in place. This tightens
+  a bound on two pre-existing methods: a caller passing a non-`Send` readiness
+  closure (rare) would need to adjust. Real-world impact is negligible, so it
+  ships in the minor rather than waiting for 2.0.
+
+### Deprecated
+- `ProcessGroup::terminate_all` — renamed to `kill_all`; the forwarding alias is
+  removed in 2.0.
+- `RunProfile::avg_cpu` — renamed to `avg_cpu_cores`; the forwarding alias is
+  removed in 2.0.
 
 ### Fixed
 -

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ async fn main() -> processkit::Result<()> {
 Signals are POSIX-only: on Windows just `Signal::Kill` is deliverable (it maps to
 the Job Object terminate) and anything else returns `Error::Unsupported`.
 `Signal::Kill` always takes the same whole-tree hard-kill path as
-`terminate_all()`. Suspend/resume work everywhere a container exists — one
+`kill_all()`. Suspend/resume work everywhere a container exists — one
 `cgroup.freeze` write covering the subtree on Linux, `SIGSTOP`/`SIGCONT` on
 macOS/BSD and the Linux process-group fallback (both idempotent), and
 per-thread suspension on Windows (best-effort; only there nested suspends
@@ -347,8 +347,8 @@ async fn main() -> processkit::Result<()> {
         .start().await?
         .profile(Duration::from_millis(100)).await?;
     println!(
-        "exit={:?} took={:?} peak_rss={:?} avg_cpu={:?}",
-        profile.exit_code, profile.duration, profile.peak_memory_bytes, profile.avg_cpu(),
+        "outcome={:?} took={:?} peak_rss={:?} avg_cpu_cores={:?}",
+        profile.outcome, profile.duration, profile.peak_memory_bytes, profile.avg_cpu_cores(),
     );
     Ok(())
 }

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -411,8 +411,8 @@ use std::time::Duration;
 
 // One run, summarized (requires the opt-in `stats` feature):
 let profile = Command::new("crunch").start().await?.profile(Duration::from_millis(100)).await?;
-println!("exit={:?} took={:?} peak_rss={:?} avg_cpu={:?}",
-    profile.exit_code, profile.duration, profile.peak_memory_bytes, profile.avg_cpu());
+println!("outcome={:?} took={:?} peak_rss={:?} avg_cpu_cores={:?}",
+    profile.outcome, profile.duration, profile.peak_memory_bytes, profile.avg_cpu_cores());
 ```
 
 For a live series over a whole group, `group.sample_stats(every)` yields a

--- a/docs/process-groups.md
+++ b/docs/process-groups.md
@@ -93,8 +93,8 @@ edges worth knowing:
 | Verb | What happens | When |
 |---|---|---|
 | `drop(group)` | Immediate **hard kill** of the whole tree (kill-on-close) | The safety net — always on |
-| `group.terminate_all()` | The same hard kill, group stays usable (cgroup-`kill` / Job Object / process-group backends). On a **pre-5.14 Linux kernel** lacking `cgroup.kill`, the per-pid `SIGKILL` fallback returns `Err` if the tree doesn't drain (a fork bomb still out-spawning, or `D`-state zombies) | Explicit teardown mid-flight; idempotent |
-| `group.shutdown().await` | Unix: `SIGTERM` → wait `shutdown_timeout` → `SIGKILL` survivors (if `escalate_to_kill`); Windows: atomic job kill. Consumes the group | Graceful service stop |
+| `group.kill_all()` | The same hard kill, group stays usable (cgroup-`kill` / Job Object / process-group backends). On a **pre-5.14 Linux kernel** lacking `cgroup.kill`, the per-pid `SIGKILL` fallback returns `Err` if the tree doesn't drain (a fork bomb still out-spawning, or `D`-state zombies) | Explicit teardown mid-flight; idempotent |
+| `group.shutdown().await` | Unix: `SIGTERM` → wait `shutdown_timeout` → `SIGKILL` survivors (if `escalate_to_kill`); Windows: atomic job kill. Consumes the group (`shutdown_ref(&self)` is the same teardown, borrowing — for a group held behind an `Arc`/supervisor) | Graceful service stop |
 
 ```rust,no_run
 use processkit::{Command, ProcessGroup, ProcessGroupOptions};
@@ -142,7 +142,7 @@ group.signal(Signal::Other(34))?;  // raw signal number escape hatch
 | Windows | `Kill` only (maps to the Job Object terminate); anything else → `Error::Unsupported` |
 
 `Signal::Kill` always takes the same *atomic* whole-tree kill path as
-`terminate_all` (`cgroup.kill` / `killpg` / job terminate), so it cannot miss
+`kill_all` (`cgroup.kill` / `killpg` / job terminate), so it cannot miss
 a process forked mid-broadcast. Other signals are a per-member broadcast —
 best-effort against a tree that is forking at that exact moment. An empty
 group accepts any deliverable signal trivially. On the **cgroup** mechanism a
@@ -183,7 +183,7 @@ Two caveats that bite in practice:
   cgroup before `exec`, so it can freeze before completing the spawn
   handshake). Windows and the pgroup backends freeze only members present at
   the call. Rule of thumb: resume before starting new work.
-- A suspended tree can still be **hard-killed** (drop / `terminate_all` /
+- A suspended tree can still be **hard-killed** (drop / `kill_all` /
   `Signal::Kill` all act on frozen processes), but a graceful `shutdown`
   starts with a `SIGTERM` the frozen tree can't act on — it would wait out the
   whole grace. Resume first for a clean shutdown.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -232,12 +232,12 @@ let profile = Command::new("crunch")
     .await?;
 
 println!(
-    "exit={:?} wall={:?} cpu={:?} peak_rss={:?} avg_cpu={:?} ({} samples)",
-    profile.exit_code,
+    "outcome={:?} wall={:?} cpu={:?} peak_rss={:?} avg_cpu_cores={:?} ({} samples)",
+    profile.outcome,            // Exited(code) / Signalled(sig) / TimedOut
     profile.duration,
     profile.cpu_time,
     profile.peak_memory_bytes,
-    profile.avg_cpu(),          // cpu / wall — e.g. Some(1.7) ≈ 1.7 cores busy
+    profile.avg_cpu_cores(),    // cpu / wall — e.g. Some(1.7) ≈ 1.7 cores busy
     profile.samples,
 );
 ```

--- a/public-api.txt
+++ b/public-api.txt
@@ -395,6 +395,8 @@ pub fn processkit::CliClient<R>::runner(&self) -> &R
 pub fn processkit::CliClient<R>::timeout(&self) -> core::option::Option<core::time::Duration>
 pub async fn processkit::CliClient<R>::try_parse<T, F>(&self, impl processkit::IntoCommand<R>, F) -> processkit::Result<T> where T: core::marker::Send, F: core::ops::function::FnOnce(&str) -> processkit::Result<T> + core::marker::Send
 pub fn processkit::CliClient<R>::with_runner(impl core::convert::AsRef<std::ffi::os_str::OsStr>, R) -> Self
+impl<R: core::clone::Clone + processkit::ProcessRunner> core::clone::Clone for processkit::CliClient<R>
+pub fn processkit::CliClient<R>::clone(&self) -> processkit::CliClient<R>
 impl<R: processkit::ProcessRunner> core::fmt::Debug for processkit::CliClient<R>
 pub fn processkit::CliClient<R>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<R> core::marker::Freeze for processkit::CliClient<R> where R: core::marker::Freeze
@@ -607,12 +609,14 @@ impl !core::panic::unwind_safe::UnwindSafe for processkit::Pipeline
 pub struct processkit::ProcessGroup
 impl processkit::ProcessGroup
 pub fn processkit::ProcessGroup::adopt(&self, &tokio::process::Child) -> processkit::Result<()>
+pub fn processkit::ProcessGroup::kill_all(&self) -> processkit::Result<()>
 pub fn processkit::ProcessGroup::mechanism(&self) -> processkit::Mechanism
 pub fn processkit::ProcessGroup::members(&self) -> processkit::Result<alloc::vec::Vec<u32>>
 pub fn processkit::ProcessGroup::new() -> processkit::Result<Self>
 pub fn processkit::ProcessGroup::resume(&self) -> processkit::Result<()>
 pub fn processkit::ProcessGroup::sample_stats(&self, core::time::Duration) -> processkit::StatsSampler<'_>
 pub async fn processkit::ProcessGroup::shutdown(self) -> processkit::Result<()>
+pub async fn processkit::ProcessGroup::shutdown_ref(&self) -> processkit::Result<()>
 pub fn processkit::ProcessGroup::signal(&self, processkit::Signal) -> processkit::Result<()>
 pub fn processkit::ProcessGroup::spawn(&self, tokio::process::Command) -> processkit::Result<tokio::process::Child>
 pub fn processkit::ProcessGroup::stats(&self) -> processkit::Result<processkit::ProcessGroupStats>
@@ -749,10 +753,14 @@ impl core::panic::unwind_safe::UnwindSafe for processkit::ResourceLimits
 pub processkit::RunProfile::cpu_time: core::option::Option<core::time::Duration>
 pub processkit::RunProfile::duration: core::time::Duration
 pub processkit::RunProfile::exit_code: core::option::Option<i32>
+pub processkit::RunProfile::outcome: processkit::Outcome
 pub processkit::RunProfile::peak_memory_bytes: core::option::Option<u64>
 pub processkit::RunProfile::samples: usize
 impl processkit::RunProfile
 pub fn processkit::RunProfile::avg_cpu(&self) -> core::option::Option<f64>
+pub fn processkit::RunProfile::avg_cpu_cores(&self) -> core::option::Option<f64>
+pub fn processkit::RunProfile::signal(&self) -> core::option::Option<i32>
+pub fn processkit::RunProfile::timed_out(&self) -> bool
 impl core::clone::Clone for processkit::RunProfile
 pub fn processkit::RunProfile::clone(&self) -> processkit::RunProfile
 impl core::cmp::Eq for processkit::RunProfile
@@ -791,8 +799,8 @@ pub async fn processkit::RunningProcess::finish(self) -> processkit::Result<proc
 pub fn processkit::RunningProcess::output_events(&mut self) -> processkit::Result<processkit::OutputEvents>
 pub fn processkit::RunningProcess::stdout_lines(&mut self) -> processkit::Result<processkit::StdoutLines>
 impl processkit::RunningProcess
-pub async fn processkit::RunningProcess::wait_for<F, Fut>(&mut self, F, core::time::Duration) -> processkit::Result<()> where F: core::ops::function::FnMut() -> Fut, Fut: core::future::future::Future<Output = bool>
-pub async fn processkit::RunningProcess::wait_for_line(&mut self, impl core::ops::function::Fn(&str) -> bool, core::time::Duration) -> processkit::Result<alloc::string::String>
+pub async fn processkit::RunningProcess::wait_for<F, Fut>(&mut self, F, core::time::Duration) -> processkit::Result<()> where F: core::ops::function::FnMut() -> Fut + core::marker::Send, Fut: core::future::future::Future<Output = bool> + core::marker::Send
+pub async fn processkit::RunningProcess::wait_for_line(&mut self, impl core::ops::function::Fn(&str) -> bool + core::marker::Send, core::time::Duration) -> processkit::Result<alloc::string::String>
 pub async fn processkit::RunningProcess::wait_for_port(&mut self, core::net::socket_addr::SocketAddr, core::time::Duration) -> processkit::Result<()>
 impl core::fmt::Debug for processkit::RunningProcess
 pub fn processkit::RunningProcess::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result

--- a/src/cassette.rs
+++ b/src/cassette.rs
@@ -193,9 +193,9 @@ fn stdin_digest_of(command: &Command) -> Option<u64> {
 /// into the match key — `content_digest` can only hash a constant discriminant
 /// for them — so two invocations differing *only* in streamed stdin would
 /// collide on one cassette key and silently replay each other's recording.
-/// Failing loud (consistent with the streaming `start` half already returning
-/// [`Error::Unsupported`]) is safer than a silent wrong answer; use a replayable
-/// source (`from_bytes`/`from_string`/`from_file`) for a recordable invocation.
+/// Failing loud is safer than a silent wrong answer; use a replayable source
+/// (`from_bytes`/`from_string`/`from_file`) for a recordable invocation. Applies
+/// to both verbs, `output_string` and `start`.
 fn reject_unrecordable_stdin(command: &Command) -> Result<()> {
     if command.stdin_source().is_some_and(|s| s.is_one_shot()) {
         return Err(Error::Unsupported {
@@ -297,8 +297,26 @@ enum Mode<R> {
 /// - The replayed result carries the *replaying* command's
 ///   [`timeout`](Command::timeout), so a recorded timed-out run surfaces as
 ///   [`Error::Timeout`](crate::Error::Timeout) with the real deadline.
-/// - Covers **`output_string`** only; `start` returns
-///   [`Error::Unsupported`](crate::Error::Unsupported).
+/// - Covers the **text and streaming verbs**: `output_string` replays the
+///   captured result, and [`start`](crate::ProcessRunner::start) replays the
+///   recorded output through a scripted [`RunningProcess`](crate::RunningProcess)
+///   (its lines flow through the command's real pumps — `stdout_lines` /
+///   `wait_for_line` / `finish` — with no subprocess). A cassette is verb-agnostic:
+///   record through either, replay through either. **Record-side caveat:**
+///   recording a `start` captures the run *whole* — the recording call drives the
+///   child to completion (via the inner runner's `output_string`) before returning
+///   the handle, so an **interactive** streaming run that must be fed stdin
+///   mid-stream can't be recorded this way (it would block waiting for input that
+///   never comes; bound it with a [`Command::timeout`](crate::Command::timeout), or
+///   script it with a [`ScriptedRunner`](crate::testing::ScriptedRunner) instead).
+/// - **The runner's `output_bytes` verb is unsupported**
+///   ([`Error::Unsupported`](crate::Error::Unsupported)) in both modes: a cassette
+///   stores lossy-UTF-8 text and cannot reproduce the exact raw bytes that verb
+///   promises — capture bytes from a real or scripted runner. (This guards the
+///   convenient default route, which would otherwise re-encode the recorded text
+///   to bytes through `start`; a streaming handle you obtain from `start` will
+///   still re-encode on its own `output_bytes` — the same lossy bytes, not the
+///   original.)
 ///
 /// Non-UTF-8 programs/args/paths are stored lossily; both sides apply the same
 /// conversion, so matching still works. Two distinct non-UTF-8 invocations that
@@ -485,6 +503,87 @@ impl<R: ProcessRunner> ProcessRunner for RecordReplayRunner<R> {
             }
         }
     }
+
+    /// Unsupported on a cassette in **either** mode. A cassette is a lossy-UTF-8
+    /// text fixture (`stdout`/`stderr` are stored as `String`), so it can neither
+    /// record nor replay the *exact* bytes `output_bytes` promises — for a binary
+    /// tool the raw bytes were already mangled to `U+FFFD` at record time. Failing
+    /// loud here keeps that contract honest rather than handing back silently-lossy
+    /// bytes through the defaulted `start` path; capture bytes from a real or
+    /// scripted runner instead.
+    async fn output_bytes(&self, _command: &Command) -> Result<ProcessResult<Vec<u8>>> {
+        Err(Error::Unsupported {
+            operation: "output_bytes on a cassette (a lossy-UTF-8 text fixture cannot \
+                        reproduce exact bytes; capture them from a real or scripted runner)"
+                .to_string(),
+        })
+    }
+
+    async fn start(&self, command: &Command) -> Result<crate::RunningProcess> {
+        reject_unrecordable_stdin(command)?;
+        match &self.mode {
+            Mode::Record {
+                inner,
+                recorded,
+                dirty,
+                ..
+            } => {
+                // Record a streaming run by capturing it whole — the real child
+                // via the inner runner's `output_string` — then hand back a
+                // scripted handle that replays the captured output through the
+                // command's real pumps. The stored `Entry` is byte-identical to
+                // the one `output_string` records, so a cassette is verb-agnostic:
+                // record through either verb, replay through either.
+                //
+                // The capture-whole trade-off on *record*: the child runs to
+                // completion before this returns, so a run that must be fed stdin
+                // *mid-stream* (interactive streaming) cannot be recorded this way
+                // — script those with a [`ScriptedRunner`](crate::testing::ScriptedRunner)
+                // instead. *Replay* has no such limit (it never spawns).
+                let result = inner.output_string(command).await?;
+                let invocation = Invocation::from_command(command);
+                let stdin_digest = stdin_digest_of(command);
+                let entry = Entry::from_parts(&invocation, &result, stdin_digest);
+                {
+                    let mut entries = recorded.lock().expect("cassette mutex poisoned");
+                    entries.push(entry.clone());
+                    dirty.store(true, Ordering::SeqCst);
+                }
+                Ok(crate::doubles::scripted_running_from_parts(
+                    command,
+                    entry.stdout,
+                    entry.stderr,
+                    entry.code,
+                    entry.timed_out,
+                    entry.signal,
+                ))
+            }
+            Mode::Replay { slots } => {
+                let invocation = Invocation::from_command(command);
+                let stdin_digest = stdin_digest_of(command);
+                let entry = {
+                    let mut slots = slots.lock().expect("cassette mutex poisoned");
+                    let Some(slot) = slots.get_mut(&key_of(&invocation, stdin_digest)) else {
+                        return Err(Error::CassetteMiss {
+                            program: command.program_name(),
+                        });
+                    };
+                    slot.play().clone()
+                };
+                // The recorded output flows through the command's real pumps on a
+                // scripted handle: `stdout_lines` / `wait_for_line` / `finish`
+                // behave as on a live child, with no subprocess.
+                Ok(crate::doubles::scripted_running_from_parts(
+                    command,
+                    entry.stdout,
+                    entry.stderr,
+                    entry.code,
+                    entry.timed_out,
+                    entry.signal,
+                ))
+            }
+        }
+    }
 }
 
 // Manual: no `R: Debug` bound; entries/slots are summarized as counts.
@@ -601,6 +700,131 @@ mod tests {
         assert_eq!(fail, fail2);
         assert_eq!(fail2.code(), Some(7));
         assert_eq!(fail2.stderr(), "boom");
+    }
+
+    #[tokio::test]
+    async fn start_records_then_replays_a_streaming_run() {
+        // The streaming verb round-trips like the bulk one: record a `start` run
+        // (captured whole), then replay it through `start` — the recorded output
+        // flows through the command's real pumps on a scripted handle, with no
+        // subprocess. Closes the gap where `start` used to return `Unsupported`.
+        let (_dir, path) = temp_cassette();
+        let inner = ScriptedRunner::new().on(
+            ["server", "--watch"],
+            Reply::lines(["starting", "listening on :8080", "ready"]),
+        );
+
+        let recorder = RecordReplayRunner::record(&path, inner);
+        let mut run = recorder
+            .start(&Command::new("server").arg("--watch"))
+            .await
+            .expect("record start");
+        let line = run
+            .wait_for_line(|l| l.contains("listening"), Duration::from_secs(5))
+            .await
+            .expect("readiness line during record");
+        assert_eq!(line, "listening on :8080");
+        assert_eq!(run.wait().await.expect("record finish"), Outcome::Exited(0));
+        recorder.save().expect("save cassette");
+
+        let replayer = RecordReplayRunner::replay(&path).expect("load cassette");
+        let mut replayed = replayer
+            .start(&Command::new("server").arg("--watch"))
+            .await
+            .expect("replay start");
+        assert_eq!(replayed.pid(), None, "a replayed handle has no OS identity");
+        let line2 = replayed
+            .wait_for_line(|l| l.contains("listening"), Duration::from_secs(5))
+            .await
+            .expect("readiness line during replay");
+        assert_eq!(line2, "listening on :8080");
+        assert_eq!(
+            replayed.wait().await.expect("replay finish"),
+            Outcome::Exited(0),
+            "replay must reproduce the recorded outcome through the streaming path"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_replay_reproduces_signal_and_timeout_outcomes() {
+        // The whole point of `Reply::from_outcome` → `into_running`: the scripted
+        // `start` handle must reproduce every non-exit outcome (not just Exited),
+        // so a recorded signal kill / timeout replays as one through the streaming
+        // path, exactly as the bulk `output_string` path already does.
+        let (_dir, path) = temp_cassette();
+        let json = serde_json::json!({
+            "version": 1,
+            "entries": [
+                { "program": "killed", "args": [], "stdout": "", "stderr": "", "signal": 9 },
+                { "program": "crashed", "args": [], "stdout": "", "stderr": "" },
+                { "program": "slow", "args": [], "stdout": "", "stderr": "", "timed_out": true }
+            ]
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+        let replayer = RecordReplayRunner::replay(&path).expect("load cassette");
+
+        let signalled = replayer
+            .start(&Command::new("killed"))
+            .await
+            .expect("replay a signalled run through start")
+            .wait()
+            .await
+            .expect("wait the signalled handle");
+        assert_eq!(signalled, Outcome::Signalled(Some(9)));
+
+        // An entry with no code/timed_out/signal is the legitimate "killed,
+        // signal unknown" — it must decode to `Signalled(None)`, not `Exited`.
+        let signalled_unknown = replayer
+            .start(&Command::new("crashed"))
+            .await
+            .expect("replay a signal-unknown run through start")
+            .wait()
+            .await
+            .expect("wait the signal-unknown handle");
+        assert_eq!(signalled_unknown, Outcome::Signalled(None));
+
+        let timed_out = replayer
+            .start(&Command::new("slow"))
+            .await
+            .expect("replay a timed-out run through start")
+            .wait()
+            .await
+            .expect("wait the timed-out handle");
+        assert_eq!(timed_out, Outcome::TimedOut);
+    }
+
+    #[tokio::test]
+    async fn output_bytes_is_unsupported_in_both_modes() {
+        // A cassette stores lossy-UTF-8 text, so `output_bytes` (exact raw bytes)
+        // must be rejected loudly rather than served silently-lossy through the
+        // now-implemented `start` path.
+        let (_dir, path) = temp_cassette();
+
+        let recorder = RecordReplayRunner::record(&path, scripted());
+        let rec_err = recorder
+            .output_bytes(&Command::new("tool").arg("--version"))
+            .await
+            .expect_err("output_bytes must be unsupported in record mode");
+        assert!(
+            matches!(rec_err, Error::Unsupported { .. }),
+            "got {rec_err:?}"
+        );
+        // The rejected call recorded nothing; a real entry is still needed to load.
+        let _ = recorder
+            .output_string(&Command::new("tool").arg("--version"))
+            .await
+            .expect("record a real entry");
+        recorder.save().expect("save");
+
+        let replayer = RecordReplayRunner::replay(&path).expect("load cassette");
+        let rep_err = replayer
+            .output_bytes(&Command::new("tool").arg("--version"))
+            .await
+            .expect_err("output_bytes must be unsupported in replay mode");
+        assert!(
+            matches!(rep_err, Error::Unsupported { .. }),
+            "got {rep_err:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -82,6 +82,15 @@ impl<R: ProcessRunner, S: AsRef<OsStr>> IntoCommand<R> for &[S] {
 ///
 /// Generic over the runner so tests inject a fake; [`new`](Self::new) uses the
 /// real job-backed [`JobRunner`].
+///
+/// `Clone` when the runner is `Clone` — the default [`JobRunner`] is, as are
+/// [`Command`] and [`Pipeline`](crate::Pipeline), so the whole CLI-wrapper family
+/// clones uniformly (e.g. to hand an owned, `'static` value to a spawned task or
+/// an async-runtime bridge). A clone copies the program, timeout, and env
+/// defaults and **shares the same default cancellation token**
+/// ([`default_cancel_on`](Self::default_cancel_on)): cancelling via one clone
+/// cancels every command built from any of them, as a shared token should.
+#[derive(Clone)]
 pub struct CliClient<R: ProcessRunner = JobRunner> {
     program: OsString,
     runner: R,
@@ -443,6 +452,24 @@ mod tests {
             dbg.contains("API_TOKEN") && dbg.contains("GIT_PAGER"),
             "env names should appear: {dbg}"
         );
+    }
+
+    #[test]
+    fn client_is_clone_with_the_default_runner() {
+        // `Command`/`Pipeline` are `Clone`; so is the default-runner `CliClient`,
+        // so the whole CLI-wrapper family clones uniformly (e.g. to own a `'static`
+        // value for a spawned task or an async-runtime bridge).
+        fn assert_clone<T: Clone>() {}
+        assert_clone::<CliClient>();
+
+        let client = CliClient::new("git")
+            .default_timeout(Duration::from_secs(3))
+            .default_env("GIT_TERMINAL_PROMPT", "0")
+            .default_cancel_on(tokio_util::sync::CancellationToken::new());
+        let clone = client.clone();
+        // Every field (program, timeout, env defaults, and the presence of a
+        // shared cancel token) survives the clone verbatim.
+        assert_eq!(format!("{client:?}"), format!("{clone:?}"));
     }
 
     crate::cli_client!(struct Demo => "git");

--- a/src/doubles.rs
+++ b/src/doubles.rs
@@ -200,13 +200,39 @@ impl Reply {
         self
     }
 
+    /// A reply reconstructed from a recorded outcome — the decode model shared
+    /// with the cassette's `Entry`: `timed_out` → timed out; else a present
+    /// `code` → exited; else a signal kill (`signal` optionally absent). Lets the
+    /// record/replay runner rebuild a streaming handle ([`into_running`](Self::into_running))
+    /// from a stored entry without duplicating `Reply`'s private shape.
+    #[cfg(feature = "record")]
+    pub(crate) fn from_outcome(
+        stdout: String,
+        stderr: String,
+        code: Option<i32>,
+        timed_out: bool,
+        signal: Option<i32>,
+    ) -> Self {
+        Self {
+            stdout,
+            stderr,
+            code: code.unwrap_or_default(),
+            timed_out,
+            // Signalled iff it neither timed out nor carries an exit code.
+            signalled: !timed_out && code.is_none(),
+            signal,
+            pending: false,
+            line_delay: None,
+        }
+    }
+
     /// Build a scripted live handle for `command` from this reply — the
     /// `start` analogue of [`into_result`](Self::into_result). The canned
     /// stdout/stderr feed the command's real pump machinery (handlers,
     /// encodings, buffer policy all apply); the scripted "process" exits with
     /// the canned code after the last delayed line (immediately without
     /// delays), or never for a [`pending`](Self::pending) reply.
-    fn into_running(self, command: &Command) -> crate::RunningProcess {
+    pub(crate) fn into_running(self, command: &Command) -> crate::RunningProcess {
         // A pending reply never exits on its own; everything else exits after
         // its (possibly zero) total line-delay budget. A canned timeout exits
         // immediately as a timed-out outcome, mirroring `into_result`.
@@ -259,6 +285,24 @@ impl Reply {
         };
         ProcessResult::new(program, self.stdout, self.stderr, outcome, timeout)
     }
+}
+
+/// Build a scripted live [`RunningProcess`](crate::RunningProcess) for `command`
+/// from recorded outcome parts — the streaming-`start` counterpart of the bulk
+/// replay path. Shared by the `record`-feature cassette so a recorded run can be
+/// replayed through `start` (its canned output flowing through the command's real
+/// pumps), not only `output_string`. The decode model matches the cassette
+/// `Entry`'s (see [`Reply::from_outcome`]).
+#[cfg(feature = "record")]
+pub(crate) fn scripted_running_from_parts(
+    command: &Command,
+    stdout: String,
+    stderr: String,
+    code: Option<i32>,
+    timed_out: bool,
+    signal: Option<i32>,
+) -> crate::RunningProcess {
+    Reply::from_outcome(stdout, stderr, code, timed_out, signal).into_running(command)
 }
 
 type Predicate = Box<dyn Fn(&Command) -> bool + Send + Sync>;

--- a/src/group.rs
+++ b/src/group.rs
@@ -248,20 +248,38 @@ impl ProcessGroup {
     /// Immediately hard-kill every process currently in the group. Idempotent;
     /// the group remains usable for further spawns afterwards.
     ///
+    /// This is an unconditional **hard** kill (`SIGKILL` / `cgroup.kill` /
+    /// `TerminateJobObject`), not a graceful `SIGTERM` — for a `SIGTERM` → grace →
+    /// `SIGKILL` teardown use [`shutdown`](Self::shutdown) /
+    /// [`shutdown_ref`](Self::shutdown_ref). The name mirrors the underlying
+    /// `Job::kill_all` it delegates to.
+    ///
     /// On the legacy per-pid kill fallback (a Linux kernel without `cgroup.kill`,
     /// pre-5.14), a tree that won't drain within the bounded sweep — a fork bomb
     /// still out-spawning, or un-reapable `D`-state zombies — surfaces as an `Err`
     /// rather than a false success; the atomic backends (`cgroup.kill`, Windows
     /// Job Object) and the process-group fallback do not report this.
-    pub fn terminate_all(&self) -> Result<()> {
+    pub fn kill_all(&self) -> Result<()> {
         #[cfg(feature = "tracing")]
         tracing::debug!(
             target: "processkit",
             mechanism = ?self.mechanism(),
-            "terminating every process in the group"
+            "hard-killing every process in the group"
         );
         self.job.kill_all().map_err(Error::Io)?;
         Ok(())
+    }
+
+    /// Renamed to [`kill_all`](Self::kill_all): the verb "terminate" reads as a
+    /// graceful `SIGTERM`, but this has always been an unconditional **hard**
+    /// kill, so the name fought the behaviour. A thin forwarding shim kept for
+    /// one minor; **removed in 2.0**.
+    #[deprecated(
+        since = "1.1.0",
+        note = "renamed to `kill_all` (it hard-kills, not a graceful SIGTERM); removed in 2.0"
+    )]
+    pub fn terminate_all(&self) -> Result<()> {
+        self.kill_all()
     }
 
     /// Broadcast `sig` to every process in the group.
@@ -277,7 +295,7 @@ impl ProcessGroup {
     ///   [`Signal::Other`] — returns [`Error::Unsupported`].
     ///
     /// `SIGKILL` ([`Signal::Kill`], or `Other(libc::SIGKILL)`) is routed through
-    /// the same whole-tree hard kill as [`terminate_all`](Self::terminate_all)
+    /// the same whole-tree hard kill as [`kill_all`](Self::kill_all)
     /// on every backend (`cgroup.kill` / `killpg` / Job Object terminate), so it
     /// cannot miss a process forked mid-broadcast. Other signals are a per-member
     /// broadcast.
@@ -307,7 +325,7 @@ impl ProcessGroup {
     ///   (level-triggered).
     ///
     /// A suspended tree can still be hard-killed
-    /// ([`terminate_all`](Self::terminate_all), or dropping the group) — SIGKILL,
+    /// ([`kill_all`](Self::kill_all), or dropping the group) — SIGKILL,
     /// `cgroup.kill`, and `TerminateJobObject` all act on frozen processes. The
     /// graceful [`shutdown`](Self::shutdown), however, starts with a `SIGTERM`
     /// that a frozen tree cannot act on until thawed, so it waits out
@@ -388,9 +406,33 @@ impl ProcessGroup {
     /// leaves `cgroup.procs` / the job on *exit*, before reaping).
     ///
     /// When `escalate_to_kill` is set, the final hard kill can surface the same
-    /// undrained-tree `Err` as [`terminate_all`](Self::terminate_all) on the
-    /// legacy pre-5.14 per-pid fallback.
+    /// undrained-tree `Err` as [`kill_all`](Self::kill_all) on the legacy pre-5.14
+    /// per-pid fallback.
+    ///
+    /// Holding the group behind a shared handle (an `Arc`, a long-lived
+    /// supervisor) that can't be moved out by value? Use the borrowing twin
+    /// [`shutdown_ref`](Self::shutdown_ref) — same teardown, `&self`.
     pub async fn shutdown(self) -> Result<()> {
+        self.shutdown_ref().await
+    }
+
+    /// Gracefully tear the group down **without consuming it** — the borrowing
+    /// twin of [`shutdown`](Self::shutdown), for a group held behind a shared
+    /// handle (an `Arc`, a supervisor) that cannot be moved out by value to call
+    /// the consuming form.
+    ///
+    /// Identical teardown to [`shutdown`](Self::shutdown): on Unix, `SIGTERM` the
+    /// tree, wait up to the configured
+    /// [`shutdown_timeout`](ProcessGroupOptions::shutdown_timeout), then `SIGKILL`
+    /// survivors when [`escalate_to_kill`](ProcessGroupOptions::escalate_to_kill)
+    /// is set; on Windows the kill is atomic and the timeout is ignored. The group
+    /// stays usable afterwards (a re-`shutdown_ref` on an already-drained tree is a
+    /// near no-op), and its `Drop` still backstops any straggler.
+    ///
+    /// The same reaping caveat as [`shutdown`](Self::shutdown) applies on the
+    /// POSIX process-group mechanism: await each child you started into the group,
+    /// or an unreaped zombie reads as alive for the whole grace.
+    pub async fn shutdown_ref(&self) -> Result<()> {
         #[cfg(feature = "tracing")]
         tracing::debug!(
             target: "processkit",

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -243,7 +243,7 @@ impl Pipeline {
                 Ok(collected) => collected?,
                 Err(_elapsed) => {
                     // Kill the chain; `_abort_guard` reaps the drain tasks as this returns.
-                    let _ = group.terminate_all();
+                    let _ = group.kill_all();
                     return Ok(ProcessResult::new(
                         self.pipeline_name(),
                         T::default(),

--- a/src/running/mod.rs
+++ b/src/running/mod.rs
@@ -407,7 +407,7 @@ impl RunningProcess {
                     return;
                 }
                 if let Some(g) = group_weak.and_then(|w| w.upgrade()) {
-                    let _ = g.terminate_all();
+                    let _ = g.kill_all();
                 }
                 stream::kill_direct_child(pid);
             }));
@@ -894,6 +894,7 @@ impl RunningProcess {
             Err(_) => (None, None, 0),
         };
         Ok(crate::stats::RunProfile {
+            outcome,
             exit_code,
             duration,
             cpu_time,
@@ -1279,7 +1280,7 @@ impl RunningProcess {
             Backend::Real(real) => {
                 let _ = real.child.start_kill();
                 if let Some(group) = &real.own_group {
-                    let _ = group.terminate_all();
+                    let _ = group.kill_all();
                 }
                 // Bound the reap: a D-state child can ignore SIGKILL until I/O
                 // unblocks, and an unbounded wait hangs shared-group handles.

--- a/src/running/probes.rs
+++ b/src/running/probes.rs
@@ -50,7 +50,7 @@ impl RunningProcess {
     ///   matching [`wait_for`](Self::wait_for) / [`wait_for_port`](Self::wait_for_port).
     pub async fn wait_for_line(
         &mut self,
-        predicate: impl Fn(&str) -> bool,
+        predicate: impl Fn(&str) -> bool + Send,
         within: Duration,
     ) -> Result<String> {
         use tokio_stream::StreamExt;
@@ -87,10 +87,19 @@ impl RunningProcess {
     /// failed probe does not kill the child. The deadline bounds the polling
     /// loop, not an in-flight check: a slow `check` future can overrun
     /// `within` by its own duration.
+    ///
+    /// `check` and its future are `Send` (matching
+    /// [`wait_for_line`](Self::wait_for_line)'s predicate and
+    /// [`Command::first_line`](crate::Command::first_line)'s), so the returned
+    /// future is `Send` — it can cross a thread boundary on a multi-threaded
+    /// runtime or be bridged onto another async runtime (e.g. a non-Rust binding
+    /// that owns the handle), not only `.await`ed in place. The future still
+    /// borrows `&mut self`, so spawning it standalone means moving the owned
+    /// [`RunningProcess`] into the surrounding `async` block to make it `'static`.
     pub async fn wait_for<F, Fut>(&mut self, check: F, within: Duration) -> Result<()>
     where
-        F: FnMut() -> Fut,
-        Fut: Future<Output = bool>,
+        F: FnMut() -> Fut + Send,
+        Fut: Future<Output = bool> + Send,
     {
         self.poll_until(check, within).await
     }
@@ -159,4 +168,20 @@ impl RunningProcess {
             timeout: within,
         }
     }
+}
+
+/// Compile-time proof that every readiness probe's future is `Send`. They must
+/// cross a `tokio::spawn` / non-Rust-runtime bridge (e.g. a Python async
+/// binding), which requires `Send + 'static` futures; a binding that re-derives
+/// readiness in its own language is duplicating semantics this crate already
+/// owns. Dropping a `+ Send` bound on a probe callback breaks the build *here*,
+/// at the crate, rather than silently in a downstream consumer.
+#[cfg(test)]
+#[allow(dead_code)]
+fn probe_futures_are_send(rp: &mut RunningProcess) {
+    fn assert_send<T: Send>(_: &T) {}
+    assert_send(&rp.wait_for_line(|line| line.is_empty(), Duration::ZERO));
+    assert_send(&rp.wait_for(|| async { true }, Duration::ZERO));
+    let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+    assert_send(&rp.wait_for_port(addr, Duration::ZERO));
 }

--- a/src/running/stream.rs
+++ b/src/running/stream.rs
@@ -315,7 +315,7 @@ impl RunningProcess {
 /// Tear down the group if still alive, then best-effort kill the direct child.
 pub(super) fn kill_via_weak(group: &Weak<ProcessGroup>, pid: Option<u32>) {
     if let Some(group) = group.upgrade() {
-        let _ = group.terminate_all();
+        let _ = group.kill_all();
     }
     kill_direct_child(pid);
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -7,7 +7,7 @@
 /// The curated variants map to the POSIX signal of the same name on Unix. On
 /// Windows only [`Kill`](Signal::Kill) is deliverable (it maps to the Job
 /// Object terminate, the same hard kill as
-/// [`terminate_all`](crate::ProcessGroup::terminate_all)); every other variant
+/// [`kill_all`](crate::ProcessGroup::kill_all)); every other variant
 /// yields [`Error::Unsupported`](crate::Error::Unsupported).
 ///
 /// [`Other`](Signal::Other) is an escape hatch carrying a raw signal number on

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -7,6 +7,7 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use crate::group::ProcessGroup;
+use crate::result::Outcome;
 
 /// A snapshot of a process group's resource usage.
 ///
@@ -132,8 +133,18 @@ impl tokio_stream::Stream for StatsSampler<'_> {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RunProfile {
-    /// The exit code; `None` for a run killed by its timeout or a signal
-    /// (matching [`RunningProcess::wait`](crate::RunningProcess::wait)).
+    /// How the run ended — the full [`Outcome`](crate::Outcome), so a profile can
+    /// distinguish a clean exit from a signal kill from a timeout (all three of
+    /// which leave [`exit_code`](Self::exit_code) `None`). Read it directly, or
+    /// via the [`signal`](Self::signal) / [`timed_out`](Self::timed_out)
+    /// convenience accessors. The profile is therefore a superset of
+    /// [`RunningProcess::wait`](crate::RunningProcess::wait): one call yields both
+    /// the resource telemetry and the run's actual outcome.
+    pub outcome: Outcome,
+    /// The exit code if the run [exited](crate::Outcome::Exited); `None` for a run
+    /// killed by its timeout or a signal. Equals
+    /// [`outcome.code()`](crate::Outcome::code) — a convenience for the common
+    /// case; consult [`outcome`](Self::outcome) to tell a timeout from a signal.
     pub exit_code: Option<i32>,
     /// Wall-clock time from process start until the run finished (exit reaped
     /// and output drained).
@@ -147,21 +158,49 @@ pub struct RunProfile {
 }
 
 impl RunProfile {
-    /// Average CPU utilisation over the run, in cores (`0.5` = half a core
+    /// Average CPU utilisation over the run, in **cores** (`0.5` = half a core
     /// busy on average; can exceed `1.0` for multi-threaded children).
     /// `None` when CPU time was never observed or the run had no duration.
-    pub fn avg_cpu(&self) -> Option<f64> {
+    pub fn avg_cpu_cores(&self) -> Option<f64> {
         let cpu = self.cpu_time?;
         if self.duration.is_zero() {
             return None;
         }
         Some(cpu.as_secs_f64() / self.duration.as_secs_f64())
     }
+
+    /// Renamed to [`avg_cpu_cores`](Self::avg_cpu_cores): the value is in CPU
+    /// **cores**, and the suffix makes the unit self-documenting. A thin
+    /// forwarding shim kept for one minor; **removed in 2.0**.
+    #[deprecated(
+        since = "1.1.0",
+        note = "renamed to `avg_cpu_cores` (the unit is cores); removed in 2.0"
+    )]
+    pub fn avg_cpu(&self) -> Option<f64> {
+        self.avg_cpu_cores()
+    }
+
+    /// The signal that killed the run, if it was
+    /// [signalled](crate::Outcome::Signalled) with a known number (`None` on a
+    /// clean exit, a timeout, or a signal kill the platform didn't number).
+    /// Shorthand for [`outcome.signal()`](crate::Outcome::signal).
+    pub fn signal(&self) -> Option<i32> {
+        self.outcome.signal()
+    }
+
+    /// Whether the run was killed by its
+    /// [timeout](crate::Outcome::TimedOut). Shorthand for
+    /// [`outcome.timed_out()`](crate::Outcome::timed_out) — distinguishes a
+    /// deadline kill from a signal kill, which [`exit_code`](Self::exit_code)
+    /// alone (both `None`) cannot.
+    pub fn timed_out(&self) -> bool {
+        self.outcome.timed_out()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::RunProfile;
+    use super::{Outcome, RunProfile};
     use std::time::Duration;
 
     #[tokio::test]
@@ -172,35 +211,67 @@ mod tests {
     }
 
     #[test]
-    fn avg_cpu_is_cpu_time_over_duration() {
+    fn avg_cpu_cores_is_cpu_time_over_duration() {
         let profile = RunProfile {
+            outcome: Outcome::Exited(0),
             exit_code: Some(0),
             duration: Duration::from_secs(2),
             cpu_time: Some(Duration::from_secs(1)),
             peak_memory_bytes: None,
             samples: 8,
         };
-        assert_eq!(profile.avg_cpu(), Some(0.5));
+        assert_eq!(profile.avg_cpu_cores(), Some(0.5));
     }
 
     #[test]
-    fn avg_cpu_is_none_without_cpu_or_duration() {
+    fn avg_cpu_cores_is_none_without_cpu_or_duration() {
         let no_cpu = RunProfile {
+            outcome: Outcome::Exited(0),
             exit_code: Some(0),
             duration: Duration::from_secs(1),
             cpu_time: None,
             peak_memory_bytes: None,
             samples: 0,
         };
-        assert_eq!(no_cpu.avg_cpu(), None);
+        assert_eq!(no_cpu.avg_cpu_cores(), None);
 
         let no_duration = RunProfile {
+            outcome: Outcome::Exited(0),
             exit_code: Some(0),
             duration: Duration::ZERO,
             cpu_time: Some(Duration::from_secs(1)),
             peak_memory_bytes: None,
             samples: 1,
         };
-        assert_eq!(no_duration.avg_cpu(), None);
+        assert_eq!(no_duration.avg_cpu_cores(), None);
+    }
+
+    #[test]
+    fn outcome_distinguishes_timeout_from_signal_when_exit_code_is_none() {
+        // The whole point of carrying `outcome`: a timeout and a signal kill both
+        // leave `exit_code == None`, yet the profile must tell them apart.
+        let timed_out = RunProfile {
+            outcome: Outcome::TimedOut,
+            exit_code: None,
+            duration: Duration::from_secs(1),
+            cpu_time: None,
+            peak_memory_bytes: None,
+            samples: 0,
+        };
+        assert!(timed_out.timed_out());
+        assert_eq!(timed_out.signal(), None);
+
+        let signalled = RunProfile {
+            outcome: Outcome::Signalled(Some(9)),
+            exit_code: None,
+            duration: Duration::from_secs(1),
+            cpu_time: None,
+            peak_memory_bytes: None,
+            samples: 0,
+        };
+        assert!(!signalled.timed_out());
+        assert_eq!(signalled.signal(), Some(9));
+        // Both leave `exit_code` empty — only `outcome` separates them.
+        assert_eq!(timed_out.exit_code, signalled.exit_code);
     }
 }

--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -665,7 +665,7 @@ impl Cgroup {
         }
         // Thaw (best-effort): the freeze only halted forking DURING the sweep.
         // Restore the cgroup unfrozen so it stays reusable for further spawns
-        // (`terminate_all` keeps the group usable; a child spawned into a frozen
+        // (`kill_all` keeps the group usable; a child spawned into a frozen
         // cgroup would itself start frozen and the spawn could block) — and so a
         // SIGKILL'd-but-frozen straggler can run its pending fatal signal and exit.
         // (This unconditionally clears any freeze a prior `suspend()` set; a kill

--- a/tests/integration/groups.rs
+++ b/tests/integration/groups.rs
@@ -161,14 +161,14 @@ async fn windows_grandchild_is_contained() {
 
 #[tokio::test]
 #[ignore = "spawns a real subprocess and kills it twice"]
-async fn terminate_all_is_idempotent() {
+async fn kill_all_is_idempotent() {
     let group = ProcessGroup::new().expect("create group");
     let child = group.start(&sleep_secs(30)).await.expect("start sleeper");
 
-    group.terminate_all().expect("first terminate");
+    group.kill_all().expect("first kill");
     group
-        .terminate_all()
-        .expect("second terminate must be a no-op success, not an error");
+        .kill_all()
+        .expect("second kill must be a no-op success, not an error");
 
     // The group stays usable after teardown: a fresh spawn still lands in it.
     // On Windows, `CreateProcess` of a binary just killed via `TerminateJobObject`

--- a/tests/integration/process_control.rs
+++ b/tests/integration/process_control.rs
@@ -179,7 +179,7 @@ async fn adopt_brings_an_external_child_under_containment() {
 
     let group = ProcessGroup::new().expect("create group");
     group.adopt(&child).expect("adopt external child");
-    group.terminate_all().expect("terminate the adopted tree");
+    group.kill_all().expect("hard-kill the adopted tree");
 
     // The adopted child must die promptly — well under its ~30s natural run.
     let _ = completes_within(Duration::from_secs(5), "adopted child reap", child.wait()).await;

--- a/tests/integration/shutdown.rs
+++ b/tests/integration/shutdown.rs
@@ -54,6 +54,58 @@ async fn shutdown_lets_a_term_handling_child_end_the_grace_early() {
 }
 
 #[tokio::test]
+#[ignore = "spawns a real subprocess and shuts it down gracefully via a shared handle"]
+async fn shutdown_ref_gracefully_tears_down_a_group_held_by_shared_reference() {
+    use std::sync::Arc;
+
+    // The borrowing twin's reason to exist: a group held behind a shared handle
+    // (here an `Arc`, as a long-lived supervisor or an FFI binding would) can't be
+    // moved out by value to call `shutdown(self)`, yet must still tear down
+    // gracefully rather than fall back to a hard kill.
+    let group = Arc::new(
+        ProcessGroup::with_options(
+            processkit::ProcessGroupOptions::default().shutdown_timeout(Duration::from_secs(10)),
+        )
+        .expect("create group"),
+    );
+
+    let mut run = group
+        .start(
+            &Command::new("sh")
+                .args(["-c", "trap 'exit 0' TERM; echo ready; read line"])
+                .keep_stdin_open(),
+        )
+        .await
+        .expect("start");
+    run.wait_for_line(|l| l.contains("ready"), Duration::from_secs(10))
+        .await
+        .expect("trap installed");
+    let waiter = tokio::spawn(run.wait());
+
+    // A second owner stays alive across the teardown, so `Arc::try_unwrap` would
+    // fail — exactly the case the by-value `shutdown` couldn't serve gracefully.
+    let _second_owner = Arc::clone(&group);
+
+    let start = Instant::now();
+    tokio::time::timeout(Duration::from_secs(20), group.shutdown_ref())
+        .await
+        .expect("shutdown_ref bounded")
+        .expect("shutdown_ref ok");
+    assert!(
+        start.elapsed() < Duration::from_secs(8),
+        "a TERM-handling child must end the 10s grace early (took {:?})",
+        start.elapsed()
+    );
+
+    let outcome = waiter.await.expect("join").expect("wait");
+    assert_eq!(
+        outcome,
+        Outcome::Exited(0),
+        "the shared-handle group still shut down gracefully (TERM trap), not hard-killed"
+    );
+}
+
+#[tokio::test]
 #[ignore = "spawns a TERM-ignoring subprocess and escalates to SIGKILL"]
 async fn shutdown_escalates_to_kill_after_the_grace_window() {
     let group = ProcessGroup::with_options(


### PR DESCRIPTION
## What & why

Additive API improvements for the next minor (1.1.0), surfaced by the `processkit-py`
PyO3 wrapper build. A binding is a stress-test of the API's *shape*: each item below
is a place the wrapper had to rename, re-wrap, or re-implement crate semantics. None
are bug fixes — they make the crate thinner to bind and better for any async consumer
(item A unblocks *any* `tokio::spawn`'d readiness wait, not just FFI; item D fixes a
real information-loss in `profile()`).

## Changes (all additive / minor-safe)

- **Probes are `Send`-bridgeable** — `wait_for_line` / `wait_for` callbacks now require
  `Send`, so the returned futures are `Send`. (Tightens a bound on two existing methods;
  real-world breakage ≈ 0 — noted under CHANGELOG `### Changed`.)
- **`ProcessGroup::shutdown_ref(&self)`** — graceful teardown that borrows the group,
  for a group held behind an `Arc`/supervisor. `shutdown(self)` delegates to it.
- **`RunProfile::outcome`** (+ `signal()`/`timed_out()`) — distinguishes exit/signal/timeout;
  `profile()` is now a superset of `wait()`.
- **Cassette streaming** — `RecordReplayRunner` covers the `start` verb (record + replay);
  `output_bytes` stays loudly unsupported (a text fixture can't reproduce exact bytes).
- **Honest names** — `kill_all` (deprecates `terminate_all`), `avg_cpu_cores`
  (deprecates `avg_cpu`); aliases removed in 2.0.
- **`CliClient: Clone`** — when its runner is `Clone`.

## Deferred to 2.0

Structured `ResourceLimit`; `OutputTooLarge` field rename; `memory_max` -> `max_memory`;
alias removals.

## Verification

clippy `--all-targets -D warnings` × 3 feature configs; `cargo test --all-features`
(301 lib + integration + stress + doctests, 0 failed); `cargo doc -D warnings`;
`cargo fmt --check`; `public-api.txt` regenerated. Reviewed in two adversarial passes.