### PR TITLE
Have ci check #[cfg(fuzzing)] code for errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,22 @@ jobs:
       # 3-OS clippy matrix; this runs on Linux for the feature dimension only.
       - run: cargo hack --feature-powerset --depth 2 check --all-targets
 
+
+  fuzz-check:
+    name: fuzz harness (cfg check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Checks the `#[cfg(fuzzing)]` code without actually running cargo-fuzz.
+      # Ordinary cargo check/clippy/test never set that cfg,
+      # so type errors would go unnoticed until fuzz.yml
+      # runs its daily schedule.
+      - run: cargo check --all-features --lib
+        env:
+          RUSTFLAGS: --cfg fuzzing
+
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/justfile
+++ b/justfile
@@ -6,12 +6,14 @@
 # `just --list` shows all recipes.
 
 # Fast everyday gate: fmt, clippy (all features), tests (all features,
-# including the real-subprocess/`--include-ignored` ones). Not a full CI
-# mirror — use `just ci` before opening a PR for that.
+# including the real-subprocess/`--include-ignored` ones), and the
+# `#[cfg(fuzzing)]` type-check. Not a full CI mirror — use `just ci` before
+# opening a PR for that.
 check:
     cargo fmt --all --check
     cargo clippy --all-targets --all-features -- -D warnings
     cargo test --all-features -- --include-ignored
+    just fuzz-check
 
 # Full local mirror of the CI workflow's stable-toolchain jobs: fmt, clippy in
 # the three feature configurations the CI matrix checks, the feature-powerset
@@ -22,7 +24,7 @@ check:
 # services/tokens (coverage/coveralls, cargo-deny, public-api diff,
 # semver-checks) — see the optional recipes below for the ones that can still
 # run locally.
-ci: fmt-check clippy-all hack test-all doc-all typos
+ci: fmt-check clippy-all hack test-all doc-all typos fuzz-check
 
 # Mirrors the CI `fmt` job.
 fmt-check:
@@ -108,6 +110,11 @@ test-musl:
             cargo test --all-features -- --include-ignored && \
             cargo test -- --include-ignored && \
             cargo test --no-default-features -- --include-ignored'
+
+# Mirrors the fuzz-check CI job. Type-checks the `#[cfg(fuzzing)]` code
+# without actually running `cargo-fuzz` or requiring a nightly toolchain.
+fuzz-check:
+    RUSTFLAGS="--cfg fuzzing" cargo check --all-features --lib
 
 # Mirrors the CI `typos` job. Requires the `typos` CLI
 # (`cargo install typos-cli`). Config/allow-list is `_typos.toml`.


### PR DESCRIPTION
## What & why

Before this commit, problems with `#[cfg(fuzzing)]`cod would go unnoticed until fuzz.yml CI tier,
which only runs on a daily schedule.

This adds a CI job to type check the #[cfg(fuzzing)] code without
actually running cargo-fuzz or needing a nightly toolchain.

It also adds a similar job to the Justfile that checks the same thing.

## Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test` passes (and `cargo test --all-features -- --ignored` if you
      touched spawn / containment / streaming paths)
- (N/A) `CHANGELOG.md` `[Unreleased]` updated when the change is user-facing
      (`Added` / `Changed` / `Fixed`)
- (N/A) Docs updated (rustdoc and the `docs/` guide set) if behavior or API changed
- (N/A) New dependencies carry a "why" comment in `Cargo.toml` (see `CONTRIBUTING.md`)

## Notes for reviewers

I came across this while working on PR #22 