### PR TITLE
Have ci check for doc errors in private items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,9 @@ jobs:
       # The crate's docs are intra-doc-link dense; a broken link degrades the
       # docs.rs page silently (doctests don't catch it). Build both the
       # docs.rs configuration (all features) and the minimal one.
-      - run: cargo doc --no-deps --all-features
+      # NOTE: The --document-private-items flag is only used with --all-features
+      # so private docs can freely reference items hidden behind feature flags.
+      - run: cargo doc --no-deps --document-private-items --all-features
         env:
           RUSTDOCFLAGS: -D warnings
       - run: cargo doc --no-deps --no-default-features

--- a/justfile
+++ b/justfile
@@ -54,7 +54,8 @@ test-all:
 # `--cfg docsrs` build is `docsrs-doc` below, since it needs a nightly
 # toolchain this recipe doesn't assume is installed).
 doc-all:
-    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+    @# Restrict --document-private-items to --all-features, just like CI
+    RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps --all-features
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features
 
 # Optional: the two nightly-toolchain CI jobs that don't need external


### PR DESCRIPTION


## What & why

Adding `--document-private-items` to 'cargo doc' is necessary to reveal problems with the documentation for private items. This flag is only used in combination with `--all-features` to ensure private docs have the freedom to reference items hidden behind feature flags.

This doesn't affect the documentation published to docs.rs.

## Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test` passes (and `cargo test --all-features -- --ignored` if you
      touched spawn / containment / streaming paths)
- (N/A) `CHANGELOG.md` `[Unreleased]` updated when the change is user-facing
      (`Added` / `Changed` / `Fixed`)
- (N/A) Docs updated (rustdoc and the `docs/` guide set) if behavior or API changed
- (N/A)  New dependencies carry a "why" comment in `Cargo.toml` (see `CONTRIBUTING.md`)

## Notes for reviewers

This breaks CI because of many private items have broken doc links.
