### PR TITLE
Fix all outstanding doc errors in private items

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -546,8 +546,8 @@ impl OutputStream {
 ///
 /// [`on_capture`](Self::on_capture) is a pure line **transform**: return the
 /// text to retain — the same line unchanged
-/// ([`Cow::Borrowed`](std::borrow::Cow::Borrowed)`(line)`), a redacted rewrite
-/// ([`Cow::Owned`](std::borrow::Cow::Owned)), or an empty string to elide the
+/// ([`Cow::Borrowed`]`(line)`), a redacted rewrite
+/// ([`Cow::Owned`]), or an empty string to elide the
 /// content while keeping the line's slot (and the exact line/byte counters).
 /// *How much* is retained and eviction on overflow stay
 /// [`OutputBufferPolicy`]'s job (the built-in [`OverflowMode`] fast path is
@@ -573,8 +573,8 @@ pub trait CapturePolicy: Send + Sync {
     /// Shape one decoded `line` from `stream` just before it enters the capture
     /// backlog, returning the text to retain.
     ///
-    /// Return [`Cow::Borrowed`](std::borrow::Cow::Borrowed)`(line)` to retain it
-    /// unchanged (no allocation), a [`Cow::Owned`](std::borrow::Cow::Owned) to
+    /// Return [`Cow::Borrowed`]`(line)` to retain it
+    /// unchanged (no allocation), a [`Cow::Owned`] to
     /// retain a rewritten/redacted line, or an empty string to blank it. The
     /// line has already had its terminator stripped (the shape
     /// [`stdout_lines`](crate::RunningProcess::stdout_lines) yields). Keep it

--- a/src/cassette.rs
+++ b/src/cassette.rs
@@ -1082,7 +1082,7 @@ enum Mode<R> {
 ///   missed the cassette entirely.
 /// - The replayed result carries the *replaying* command's
 ///   [`timeout`](Command::timeout), so a recorded timed-out run surfaces as
-///   [`ErrorReason::Timeout`](crate::ErrorReason::Timeout) with the real deadline.
+///   [`ErrorReason::Timeout`] with the real deadline.
 /// - Covers the **text and streaming verbs**: `output_string` replays the
 ///   captured result, and [`start`](crate::ProcessRunner::start) replays the
 ///   recorded output through a scripted [`RunningProcess`](crate::RunningProcess)
@@ -1096,7 +1096,7 @@ enum Mode<R> {
 ///   never comes; bound it with a [`Command::timeout`](crate::Command::timeout), or
 ///   script it with a [`ScriptedRunner`](crate::testing::ScriptedRunner) instead).
 /// - **The runner's `output_bytes` verb is unsupported**
-///   ([`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported)) in both modes: a cassette
+///   ([`ErrorReason::Unsupported`]) in both modes: a cassette
 ///   stores lossy-UTF-8 text and cannot reproduce the exact raw bytes that verb
 ///   promises — capture bytes from a real or scripted runner. (This guards the
 ///   convenient default route, which would otherwise re-encode the recorded text

--- a/src/client.rs
+++ b/src/client.rs
@@ -424,7 +424,7 @@ impl<R: ProcessRunner> CliClient<R> {
     /// Run, returning stdout (trailing whitespace trimmed) on success (errors on
     /// a non-zero exit) — the same verb, with the same semantics, as
     /// [`Command::run`](crate::Command::run) and
-    /// [`ProcessRunnerExt::run`](crate::ProcessRunnerExt::run). Trims with
+    /// [`ProcessRunnerExt::run`]. Trims with
     /// `trim_end`: the trailing newline is noise, but leading whitespace can be
     /// significant.
     ///
@@ -447,7 +447,7 @@ impl<R: ProcessRunner> CliClient<R> {
 
     /// Run, requiring an accepted exit, and return the full
     /// [`ProcessResult`] (untrimmed) — the [`CliClient`] analogue of
-    /// [`ProcessRunnerExt::checked`](crate::ProcessRunnerExt::checked); the
+    /// [`ProcessRunnerExt::checked`]; the
     /// building block when you need the whole result after success-checking.
     ///
     /// # Errors
@@ -494,7 +494,7 @@ impl<R: ProcessRunner> CliClient<R> {
 
     /// Run for the side effect, discarding stdout (errors on a non-zero exit) —
     /// the same verb as
-    /// [`ProcessRunnerExt::run_unit`](crate::ProcessRunnerExt::run_unit).
+    /// [`ProcessRunnerExt::run_unit`].
     ///
     /// # Errors
     ///
@@ -535,7 +535,7 @@ impl<R: ProcessRunner> CliClient<R> {
 
     /// Stream stdout and return the first line matching `predicate` (`None` if
     /// the stream ends first) — the [`CliClient`] analogue of
-    /// [`ProcessRunnerExt::first_line`](crate::ProcessRunnerExt::first_line),
+    /// [`ProcessRunnerExt::first_line`],
     /// bounded by the command's [`timeout`](crate::Command::timeout).
     ///
     /// # Errors
@@ -561,7 +561,7 @@ impl<R: ProcessRunner> CliClient<R> {
     /// Run (errors on a non-zero exit) and feed stdout to an infallible
     /// `parse` — the shape of git/jj struct-returning commands. Fails loud on a
     /// bounded-buffer truncation. Delegates to
-    /// [`ProcessRunnerExt::parse`](crate::ProcessRunnerExt::parse).
+    /// [`ProcessRunnerExt::parse`].
     ///
     /// # Errors
     ///
@@ -582,7 +582,7 @@ impl<R: ProcessRunner> CliClient<R> {
     /// the shape of JSON deserialization, where a parse failure becomes
     /// [`ErrorReason::Parse`](crate::ErrorReason::Parse). Fails loud on a bounded-buffer
     /// truncation. Delegates to
-    /// [`ProcessRunnerExt::try_parse`](crate::ProcessRunnerExt::try_parse).
+    /// [`ProcessRunnerExt::try_parse`].
     ///
     /// # Errors
     ///

--- a/src/command.rs
+++ b/src/command.rs
@@ -330,7 +330,7 @@ impl Command {
     /// the child's own working directory once [`current_dir`](Self::current_dir)
     /// is also set.
     ///
-    /// If resolution fails everywhere, [`ErrorReason::NotFound`](crate::ErrorReason::NotFound)'s
+    /// If resolution fails everywhere, [`ErrorReason::NotFound`]'s
     /// `searched` includes these directories — first, in priority order — ahead
     /// of the `PATH` directories, so the diagnostic doesn't hide that they were
     /// checked too.
@@ -445,7 +445,7 @@ impl Command {
     /// [`gid`](Self::gid) — the group id is set **before** the user id (once
     /// the uid drops, changing gid is no longer permitted), an ordering the
     /// standard library guarantees. On non-Unix targets the run fails with
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) — a requested
+    /// [`ErrorReason::Unsupported`] — a requested
     /// privilege drop is never silently skipped.
     ///
     /// **Linux cgroup caveat:** under the cgroup v2 mechanism
@@ -481,7 +481,7 @@ impl Command {
     /// Ordering is handled for you: the OS applies `setgroups` → `setgid` →
     /// `setuid` (groups and gid must be set while still privileged, before the
     /// uid drops). On non-Unix targets the run fails with
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) — never silently
+    /// [`ErrorReason::Unsupported`] — never silently
     /// skipped. The Linux cgroup-v2 caveat from [`uid`](Self::uid) applies
     /// unchanged.
     pub fn groups(mut self, gids: impl AsRef<[u32]>) -> Self {
@@ -495,7 +495,7 @@ impl Command {
     /// Containment is preserved: the group tracks the new session's process
     /// group (whose id is the child's pid), so kill-on-drop and the teardown
     /// verbs still reach it. On non-Unix targets the run fails with
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported).
+    /// [`ErrorReason::Unsupported`].
     ///
     /// Honored by the `Command`-driven launch paths (`run`/`output_*`/
     /// `start`, [`ProcessGroup::start`](crate::ProcessGroup::start),
@@ -517,7 +517,7 @@ impl Command {
     /// a priority-class flag OR'd into `creation_flags`, the same seam as
     /// [`create_no_window`](Self::create_no_window). Unlike the privilege
     /// builders this never yields
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) — see
+    /// [`ErrorReason::Unsupported`] — see
     /// [`Priority`](crate::Priority) for why both platforms cover every
     /// variant, and the Unix caveat that lowering `nice` below its inherited
     /// value — [`Priority::AboveNormal`](crate::Priority::AboveNormal)/
@@ -538,7 +538,7 @@ impl Command {
     /// `pre_exec` seam as [`priority`](Self::priority) and
     /// [`umask`](Self::umask). Linux is the only supported platform: Windows,
     /// macOS, BSD, and other Unix targets fail with
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) rather than
+    /// [`ErrorReason::Unsupported`] rather than
     /// silently inheriting the caller's I/O priority. See [`IoPriority`](crate::IoPriority)
     /// for the Linux classes, data range, and privilege caveat.
     ///
@@ -556,7 +556,7 @@ impl Command {
     /// Applied via `pre_exec`, alongside [`setsid`](Self::setsid)/
     /// [`groups`](Self::groups) — another knob on that same seam. On
     /// non-Unix targets the run fails with
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) rather than
+    /// [`ErrorReason::Unsupported`] rather than
     /// silently ignoring the requested mask. Only the low permission bits are
     /// meaningful (as with the `umask(2)` syscall itself); pass the value you
     /// would give the `umask` shell builtin, e.g. `0o022`.
@@ -861,7 +861,7 @@ impl Command {
     ///
     /// Outside a [`Pipeline`](crate::Pipeline) this is a **no-op**: a single
     /// run's status is already plain data in its
-    /// [`ProcessResult`](crate::ProcessResult), and
+    /// [`ProcessResult`], and
     /// [`ensure_success`](crate::ProcessResult::ensure_success) stays opt-in
     /// — `unchecked` does not relax it, nor a whole-chain
     /// [`Pipeline::timeout`](crate::Pipeline::timeout).
@@ -975,7 +975,7 @@ impl Command {
 
     /// Treat these exit codes (not just `0`) as success for the checking verbs —
     /// [`run`](Self::run) (and `run_unit`/`checked` via
-    /// [`ProcessRunnerExt`](crate::ProcessRunnerExt)) and
+    /// [`ProcessRunnerExt`]) and
     /// [`ProcessResult::ensure_success`] / [`is_success`](ProcessResult::is_success).
     /// For tools whose non-zero exit is a normal result — `grep` (1 = no match),
     /// `diff` (1 = differs), rsync's code families — so callers don't hand-match.
@@ -996,7 +996,7 @@ impl Command {
     /// Tie this run to `token`: cancelling it kills the process tree and makes
     /// every consuming path (`run`/`output_string`/`output_bytes`/`wait`/
     /// `exit_code`/`probe`/`profile`/`finish` and the streamed
-    /// finishers) resolve to [`ErrorReason::Cancelled`](crate::ErrorReason::Cancelled).
+    /// finishers) resolve to [`ErrorReason::Cancelled`].
     /// In a [`Pipeline`](crate::Pipeline), a token on any stage cancels that
     /// stage and the cancellation errors the whole pipeline (the private
     /// pipeline group tears the other stages down).
@@ -1017,7 +1017,7 @@ impl Command {
     /// pre-spawn short-circuit. A mid-run cancel during
     /// [`wait_for_line`](crate::RunningProcess::wait_for_line), by contrast,
     /// closes the stream and surfaces as that probe's
-    /// [`ErrorReason::NotReady`](crate::ErrorReason::NotReady), not `Cancelled` — the
+    /// [`ErrorReason::NotReady`], not `Cancelled` — the
     /// consuming finisher afterwards still reports `Cancelled`.
     ///
     /// A cancelled run is never retried: [`retry`](Self::retry) policies and
@@ -1041,10 +1041,10 @@ impl Command {
     ///
     /// Applies to the **success-checking** helpers —
     /// `run`/`run_unit`/`checked`/`exit_code`/`probe`/`parse`/`try_parse` — on
-    /// [`Command`](Self::run), on [`ProcessRunnerExt`](crate::ProcessRunnerExt),
+    /// [`Command`](Self::run), on [`ProcessRunnerExt`],
     /// and on [`CliClient`](crate::CliClient): the ones that surface failure as an
     /// [`Error`] the classifier can inspect (e.g. a transient network failure in
-    /// `stderr`, or [`ErrorReason::Timeout`](crate::ErrorReason::Timeout)). The non-erroring
+    /// `stderr`, or [`ErrorReason::Timeout`]). The non-erroring
     /// `output_string`/`output_bytes` paths don't retry.
     ///
     /// Each attempt **re-executes the whole command** — a fresh process. Only
@@ -1082,7 +1082,7 @@ impl Command {
     /// Use a reusable source (`from_string`/`from_bytes`/`from_file`/
     /// `from_iter_lines`) to retry unconditionally. (A one-shot source *re-run*
     /// outside this retry loop — a `Supervisor` incarnation, a pipeline re-run —
-    /// does fail loud with [`ErrorReason::Io`](crate::ErrorReason::Io) `InvalidInput` at
+    /// does fail loud with [`ErrorReason::Io`] `InvalidInput` at
     /// launch instead.)
     ///
     /// **Inert outside the success-checking verbs.** A `retry` policy is
@@ -1202,7 +1202,7 @@ impl Command {
     /// interactive pipe. Setting `inherit_stdin` **and** one of those is a
     /// contradiction (feed the child a source *and* let it read the terminal?),
     /// so it is rejected at the launch boundary with a typed
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) (`InvalidInput`) — the same failure mode
+    /// [`ErrorReason::Io`] (`InvalidInput`) — the same failure mode
     /// as the other stdin misconfiguration the crate refuses (re-running a
     /// consumed one-shot source) — rather than silently letting one win. Drop the
     /// other stdin knob to resolve it.
@@ -1263,7 +1263,7 @@ impl Command {
     }
 
     /// Set how the child's standard output stream is connected (default:
-    /// [`StdioMode::Piped`](crate::StdioMode::Piped)).
+    /// [`StdioMode::Piped`]).
     ///
     /// - **`Piped`** (default) — captured into a pipe; all output-retrieval
     ///   verbs (`output_string`, `stdout_lines`, …) read from it.
@@ -1284,7 +1284,7 @@ impl Command {
     }
 
     /// Set how the child's standard error stream is connected (default:
-    /// [`StdioMode::Piped`](crate::StdioMode::Piped)).
+    /// [`StdioMode::Piped`]).
     ///
     /// Same semantics as [`stdout`](Self::stdout): `Piped` captures,
     /// `Inherit` passes through, `Null` suppresses.
@@ -1558,7 +1558,7 @@ impl Command {
     /// so the value the policy returns (not the raw line) is what lands in the
     /// capture backlog and therefore in
     /// [`output_string`](crate::RunningProcess::output_string) /
-    /// [`ProcessResult`](crate::ProcessResult) and the streaming verbs
+    /// [`ProcessResult`] and the streaming verbs
     /// ([`stdout_lines`](crate::RunningProcess::stdout_lines) /
     /// [`events`](crate::RunningProcess::events)).
     ///
@@ -1571,7 +1571,7 @@ impl Command {
     /// redacts env *values*).
     ///
     /// A single whole-command knob (like [`output_buffer`](Self::output_buffer)):
-    /// the policy is handed the [`OutputStream`](crate::OutputStream) each line
+    /// the policy is handed the [`OutputStream`] each line
     /// came from, so one implementation can treat stdout and stderr differently.
     /// A repeat call replaces the previous policy (builder semantics).
     ///
@@ -1693,7 +1693,7 @@ impl Command {
     /// switches, and OSC title/hyperlink escapes: with this on, the line predicates
     /// ([`wait_for_line`](crate::RunningProcess::wait_for_line) / `first_line`),
     /// [`output_string`](crate::RunningProcess::output_string) /
-    /// [`ProcessResult`](crate::ProcessResult), and the streaming verbs
+    /// [`ProcessResult`], and the streaming verbs
     /// ([`stdout_lines`](crate::RunningProcess::stdout_lines) /
     /// [`events`](crate::RunningProcess::events)) all carry the de-escaped text.
     /// It drops CSI (`ESC [ … final`), OSC (`ESC ] … BEL/ST`), DCS/SOS/PM/APC
@@ -1713,7 +1713,7 @@ impl Command {
     /// [`capture_policy`](Self::capture_policy), sanitization runs **first** so a
     /// secret-scrubbing policy matches on already-cleaned text (a token cannot
     /// hide behind a color escape). A line past an
-    /// [`OutputBufferPolicy`](crate::OutputBufferPolicy) byte cap is judged on its
+    /// [`OutputBufferPolicy`] byte cap is judged on its
     /// **raw** length (before this transform) and, if over-cap, is never assembled
     /// — so, like the handlers/tee, sanitization never sees it.
     ///
@@ -1848,7 +1848,7 @@ impl Command {
     /// `PATH` away from the process `PATH` — an explicit `PATH` override/removal,
     /// [`env_clear`](Self::env_clear), or [`inherit_env`](Self::inherit_env)
     /// (which clears the inherited set). When true, the *`PATH`*-directory
-    /// naming in [`ErrorReason::NotFound`](crate::ErrorReason::NotFound) is skipped:
+    /// naming in [`ErrorReason::NotFound`] is skipped:
     /// `find_in_path` reads the *process* `PATH`, so against a custom child
     /// `PATH` that list would be wrong. [`prefer_local`](Self::prefer_local)
     /// directories are unaffected by this gate and still get named — they're
@@ -2250,7 +2250,7 @@ impl Command {
     /// [`timeout`](Self::timeout)/[`cancel_on`](Self::cancel_on)/
     /// [`timeout_grace`](Self::timeout_grace)/
     /// [`windows_graceful_ctrl_break`](Self::windows_graceful_ctrl_break) wiring —
-    /// you drive the bare [`tokio::process::Child`](tokio::process::Child) (draining
+    /// you drive the bare [`tokio::process::Child`] (draining
     /// its pipes, reaping it) yourself. On Windows,
     /// [`ProcessGroup::spawn`](crate::ProcessGroup::spawn) re-sets the child's
     /// creation flags to make containment race-free, so a creation flag left on this
@@ -2262,8 +2262,8 @@ impl Command {
     ///
     /// The same preflight failures a normal launch would raise while resolving the
     /// program / opening a `stdout_file` redirect
-    /// ([`ErrorReason::Io`](crate::ErrorReason::Io)), plus
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) for a
+    /// ([`ErrorReason::Io`]), plus
+    /// [`ErrorReason::Unsupported`] for a
     /// Linux-only I/O-priority request on another platform.
     pub fn to_tokio_command(&self) -> Result<tokio::process::Command> {
         self.build_tokio()
@@ -2600,7 +2600,7 @@ impl Command {
     /// for everything else, `start`/`run`/`output_*` are what you want.
     ///
     /// The returned [`DetachedChild`] is a **separate, non-interchangeable type**
-    /// (not a [`RunningProcess`](crate::RunningProcess)) carrying nothing but the
+    /// (not a [`RunningProcess`]) carrying nothing but the
     /// [`pid`](DetachedChild::pid) — no `kill`, no timeout, no capture, no
     /// teardown — precisely because it is no longer contained.
     ///
@@ -2638,7 +2638,7 @@ impl Command {
     ///
     /// A detached child has no owner to enforce a timeout, no pump to capture
     /// output, and no interactive stdin, so a `Command` carrying any of those knobs
-    /// is refused with [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported)
+    /// is refused with [`ErrorReason::Unsupported`]
     /// naming it — **never** silently ignored (the same "fail loud, don't drop a
     /// requested behavior" contract as `uid`/`gid`/`umask` off Unix). The refused
     /// knobs are: [`timeout`](Self::timeout)/[`timeout_grace`](Self::timeout_grace),
@@ -2665,12 +2665,12 @@ impl Command {
     ///
     /// # Errors
     ///
-    /// - [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) — an
+    /// - [`ErrorReason::Unsupported`] — an
     ///   incompatible knob (above), or a POSIX-only privilege primitive requested
     ///   off Unix.
-    /// - [`ErrorReason::NotFound`](crate::ErrorReason::NotFound) — the program could
+    /// - [`ErrorReason::NotFound`] — the program could
     ///   not be located.
-    /// - [`ErrorReason::Spawn`](crate::ErrorReason::Spawn) — the program was located
+    /// - [`ErrorReason::Spawn`] — the program was located
     ///   but the OS refused to start it (bad working directory, permission denied, a
     ///   Windows `.cmd`/`.bat` that needs `cmd.exe`, …).
     ///
@@ -2738,7 +2738,7 @@ impl Command {
 
     /// Reject a `Command` configuration [`spawn_detached`](Self::spawn_detached)
     /// cannot honor — loudly and typed, never silently ignored. Each incompatible
-    /// knob surfaces as [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported)
+    /// knob surfaces as [`ErrorReason::Unsupported`]
     /// naming it, matching the crate's precedent for a refused spawn-time request
     /// (`uid`/`gid`/`umask` off Unix).
     fn ensure_detach_compatible(&self) -> Result<()> {
@@ -2930,7 +2930,7 @@ impl Command {
     ///   a previous run.
     #[cfg_attr(
         feature = "limits",
-        doc = "- [`ErrorReason::ResourceLimit`](crate::ErrorReason::ResourceLimit) — a resource cap configured on the run's group could not be enforced."
+        doc = "- [`ErrorReason::ResourceLimit`] — a resource cap configured on the run's group could not be enforced."
     )]
     pub async fn start(&self) -> Result<RunningProcess> {
         JobRunner::new().start(self).await
@@ -2970,9 +2970,9 @@ impl Command {
 
     /// Run to completion and return just the exit code (output is discarded). A
     /// run that yields no code surfaces as an error — a timeout as
-    /// [`ErrorReason::Timeout`](crate::ErrorReason::Timeout), a signal-kill as
-    /// [`ErrorReason::Signalled`](crate::ErrorReason::Signalled) — consistent with
-    /// [`ProcessRunnerExt::exit_code`](crate::ProcessRunnerExt::exit_code) and
+    /// [`ErrorReason::Timeout`], a signal-kill as
+    /// [`ErrorReason::Signalled`] — consistent with
+    /// [`ProcessRunnerExt::exit_code`] and
     /// [`CliClient::exit_code`](crate::CliClient::exit_code).
     ///
     /// # Errors
@@ -2987,7 +2987,7 @@ impl Command {
 
     /// Run to completion, requiring an **accepted** exit (`0` by default, widened
     /// by [`ok_codes`](Self::ok_codes)), and return trimmed stdout. Any other
-    /// code is [`ErrorReason::Exit`](crate::ErrorReason::Exit).
+    /// code is [`ErrorReason::Exit`].
     ///
     /// # Errors
     ///
@@ -3007,7 +3007,7 @@ impl Command {
     /// captured [`ProcessResult`] (untrimmed stdout) — the building block when you
     /// need the whole result after success-checking rather than trimmed stdout
     /// ([`run`](Self::run)) or the raw result ([`output_string`](Self::output_string)).
-    /// Consistent with [`ProcessRunnerExt::checked`](crate::ProcessRunnerExt::checked)
+    /// Consistent with [`ProcessRunnerExt::checked`]
     /// and [`CliClient::checked`](crate::CliClient::checked).
     ///
     /// # Errors
@@ -3025,7 +3025,7 @@ impl Command {
 
     /// Run for the side effect: require an **accepted** exit (`0`, or any code in
     /// [`ok_codes`](Self::ok_codes)) and discard the output. Consistent with
-    /// [`ProcessRunnerExt::run_unit`](crate::ProcessRunnerExt::run_unit) and
+    /// [`ProcessRunnerExt::run_unit`] and
     /// [`CliClient::run_unit`](crate::CliClient::run_unit).
     ///
     /// # Errors
@@ -3040,8 +3040,8 @@ impl Command {
 
     /// Run a predicate command and read its exit code as a boolean: exit `0` →
     /// `Ok(true)`, exit `1` → `Ok(false)`, anything else → `Err` (any other code
-    /// as [`ErrorReason::Exit`], a timeout as [`ErrorReason::Timeout`](crate::ErrorReason::Timeout),
-    /// a signal-kill as [`ErrorReason::Signalled`](crate::ErrorReason::Signalled)). For tools
+    /// as [`ErrorReason::Exit`], a timeout as [`ErrorReason::Timeout`],
+    /// a signal-kill as [`ErrorReason::Signalled`]). For tools
     /// whose exit code *is* the answer —
     /// `git diff --quiet`, `git show-ref --verify --quiet`, `grep -q`, …
     ///
@@ -3059,7 +3059,7 @@ impl Command {
     /// Run (requiring an **accepted** exit) and feed stdout to an **infallible**
     /// `parse` closure, returning the parsed value. Fails loud on a bounded-buffer
     /// truncation so the parser never sees a clipped tail. Consistent with
-    /// [`ProcessRunnerExt::parse`](crate::ProcessRunnerExt::parse) and
+    /// [`ProcessRunnerExt::parse`] and
     /// [`CliClient::parse`](crate::CliClient::parse).
     ///
     /// # Errors
@@ -3079,16 +3079,16 @@ impl Command {
 
     /// Run (requiring an **accepted** exit) and feed stdout to a *fallible*
     /// `parse` closure (the JSON-deserialization shape; a failure becomes
-    /// [`ErrorReason::Parse`](crate::ErrorReason::Parse) or whatever the closure returns).
+    /// [`ErrorReason::Parse`] or whatever the closure returns).
     /// Fails loud on truncation. Consistent with
-    /// [`ProcessRunnerExt::try_parse`](crate::ProcessRunnerExt::try_parse) and
+    /// [`ProcessRunnerExt::try_parse`] and
     /// [`CliClient::try_parse`](crate::CliClient::try_parse).
     ///
     /// # Errors
     ///
     /// Everything [`parse`](Self::parse) can return, plus whatever the fallible
     /// `parse` closure yields on malformed output — typically
-    /// [`ErrorReason::Parse`](crate::ErrorReason::Parse).
+    /// [`ErrorReason::Parse`].
     pub async fn try_parse<T, F>(&self, parse: F) -> Result<T>
     where
         T: Send,
@@ -3150,7 +3150,7 @@ impl Command {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::NotFound`](crate::ErrorReason::NotFound) when the program can't be
+    /// [`ErrorReason::NotFound`] when the program can't be
     /// located — not installed, not on `PATH`, or a path that doesn't resolve to
     /// an executable. Its `searched` field lists the directories that were
     /// checked (`prefer_local` first, then `PATH`) for a bare-name lookup, and is
@@ -3466,7 +3466,7 @@ pub(crate) enum PathSource {
 
 /// The outcome of resolving a command's `program` to a concrete executable path
 /// **without spawning it** — the single decision the live launch path's
-/// [`ErrorReason::NotFound`](crate::ErrorReason::NotFound) enrichment (in `runner.rs`) and
+/// [`ErrorReason::NotFound`] enrichment (in `runner.rs`) and
 /// the spawn-free [`which`](crate::which) / [`Command::resolve_program`]
 /// preflight both derive from, so the two can never disagree about whether a
 /// program is available.
@@ -3477,7 +3477,7 @@ pub(crate) enum ProgramResolution {
     /// name the same way [`find_in_path_in`] models; preflight returns it.
     Found(PathBuf),
     /// Not resolvable. `searched` is the directory list for
-    /// [`ErrorReason::NotFound`](crate::ErrorReason::NotFound)'s field: `Some` for a
+    /// [`ErrorReason::NotFound`]'s field: `Some` for a
     /// bare-name `PATH` lookup (the searched dirs, `prefer_local` first),
     /// `None` for a path-form program (no `PATH` search applied).
     NotFound { searched: Option<String> },
@@ -3607,7 +3607,7 @@ pub(crate) fn probe_prefer_local(dirs: &[PathBuf], program: &OsStr) -> Option<Pa
 }
 
 /// Build the combined `searched` diagnostic for
-/// [`ErrorReason::NotFound`](crate::ErrorReason::NotFound): the [`Command::prefer_local`]
+/// [`ErrorReason::NotFound`]: the [`Command::prefer_local`]
 /// directories (first, in priority order) followed by the `PATH` directories
 /// (`path_searched`, as returned by [`find_in_path`]) — joined by the
 /// platform's `PATH`-list separator (`:` on Unix, `;` on Windows), matching

--- a/src/doc_examples.rs
+++ b/src/doc_examples.rs
@@ -32,10 +32,17 @@
     feature = "record",
     feature = "pty"
 ))]
+// These hidden modules exist only to register fenced examples as doctests. Their
+// mdBook links are ordinary Markdown URLs (and often use downstream
+// `processkit::...` paths), not intra-doc links in this private module hierarchy.
+#[allow(rustdoc::broken_intra_doc_links)]
 mod guides {
     /// `README.md` (crate root) — kept **out** of the rendered crate doc
     /// (see `decisions/readme-crate-doc-sourcing.md`); included here only so its
     /// fenced Rust blocks run as doctests.
+    ///
+    /// README.md's relative file links (e.g. to `LICENSE`) aren't intra-doc
+    /// links; only `--document-private-items` builds check them.
     #[doc(hidden)]
     #[doc = include_str!("../README.md")]
     mod readme {}

--- a/src/doubles.rs
+++ b/src/doubles.rs
@@ -10,7 +10,7 @@
 //!   snapshot and/or a callback, and returns a synthetic successful result —
 //!   the seam behind a tool's own `--dry-run` echo mode.
 //!
-//! Behind the `mock` feature, [`mockall`] additionally generates a `MockRunner`
+//! Behind the `mock` feature, `mockall` additionally generates a `MockRunner`
 //! for expectation-style mocking. All of these live under
 //! [`processkit::testing`](crate::testing), not the crate root.
 //!
@@ -27,7 +27,7 @@
 //! `output_string` replay also does not model a bounded-buffer **truncation** policy
 //! (a canned reply is returned whole, `truncated() == false`), so the
 //! checking-verb truncation error won't fire against a bulk double — to
-//! exercise that, drive output through a scripted [`start`] handle (whose canned
+//! exercise that, drive output through a scripted [`start`](crate::ProcessRunner::start) handle (whose canned
 //! lines flow through the real buffer policy).
 //!
 //! Instant replies never observe a `cancel_on` token (they resolve before any
@@ -489,7 +489,7 @@ impl Reply {
     /// path would hand back for the same output.
     ///
     /// The live bulk path decodes the child's bytes, splits them into lines under
-    /// the command's [`LineTerminator`], then rejoins with `\n`
+    /// the command's [`LineTerminator`](crate::LineTerminator), then rejoins with `\n`
     /// (`stdout_lines.join("\n")`) — so a trailing terminator is dropped and CRLF
     /// is normalized to LF. Canned text gets the *same* treatment here (via
     /// [`split_pump_lines`](crate::running::split_pump_lines)), so
@@ -941,7 +941,7 @@ fn commit_stdin_reservation(reservation: Option<crate::stdin::StdinReservation>)
 /// scripted/real `start`, the live pumps invoke the handlers instead.
 ///
 /// Splits the canned text with [`split_pump_lines`](crate::running::split_pump_lines)
-/// under the command's per-stream [`LineTerminator`], exactly as the live pump
+/// under the command's per-stream [`LineTerminator`](crate::LineTerminator), exactly as the live pump
 /// does — so the lines a handler sees on the fake match the ones a real run would
 /// deliver (and the ones `into_result` joins back into the result).
 pub(crate) fn replay_line_handlers(command: &Command, stdout: &str, stderr: &str) {

--- a/src/group.rs
+++ b/src/group.rs
@@ -144,7 +144,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) if the OS rejects creating the group's containment primitive
+    /// [`crate::ErrorReason::Io`] if the OS rejects creating the group's containment primitive
     /// (a Job Object on Windows, a cgroup on Linux). The default options set no
     /// resource caps, so no limit-enforcement failure can arise.
     pub fn new() -> Result<Self> {
@@ -155,7 +155,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) if the OS rejects creating the group's containment primitive.
+    /// [`crate::ErrorReason::Io`] if the OS rejects creating the group's containment primitive.
     #[cfg_attr(
         feature = "limits",
         doc = "",
@@ -163,9 +163,9 @@ impl ProcessGroup {
         doc = "now. When the active mechanism can't honor a requested limit (no",
         doc = "cgroup/Job Object, or a Linux cgroup whose controllers can't be enabled —",
         doc = "see [`ResourceLimits`] for the cgroup-v2 real-root requirement) this",
-        doc = "returns [`ErrorReason::ResourceLimit`](crate::ErrorReason::ResourceLimit) — rather than handing back an unbounded",
+        doc = "returns [`crate::ErrorReason::ResourceLimit`] — rather than handing back an unbounded",
         doc = "group — and an invalid cap value returns it too, with",
-        doc = "[`LimitReason::Invalid`](crate::LimitReason::Invalid)."
+        doc = "[`LimitReason::Invalid`]."
     )]
     pub fn with_options(options: ProcessGroupOptions) -> Result<Self> {
         #[cfg(feature = "limits")]
@@ -236,10 +236,10 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Spawn`](crate::ErrorReason::Spawn) if the OS refuses to start `cmd` — the working directory
+    /// [`crate::ErrorReason::Spawn`] if the OS refuses to start `cmd` — the working directory
     /// is bad, permission is denied, and so on. (This raw path reports every
-    /// launch failure as [`ErrorReason::Spawn`](crate::ErrorReason::Spawn); the `Command`-driven run helpers, by
-    /// contrast, translate a not-found program into [`ErrorReason::NotFound`](crate::ErrorReason::NotFound).)
+    /// launch failure as [`crate::ErrorReason::Spawn`]; the `Command`-driven run helpers, by
+    /// contrast, translate a not-found program into [`crate::ErrorReason::NotFound`].)
     pub fn spawn(&self, mut cmd: Command) -> Result<Child> {
         self.spawn_with_options(&mut cmd, &crate::sys::SpawnOptions::default())
     }
@@ -307,7 +307,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) if `child` has already been reaped (awaited), leaving no
+    /// [`crate::ErrorReason::Io`] if `child` has already been reaped (awaited), leaving no
     /// live handle/pid to reference. Adopting an exited-but-unreaped child is a
     /// successful no-op.
     #[cfg(feature = "process-control")]
@@ -354,7 +354,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) in two cases, both on the non-atomic Unix backends: the legacy
+    /// [`crate::ErrorReason::Io`] in two cases, both on the non-atomic Unix backends: the legacy
     /// per-pid kill fallback (a pre-5.14 Linux kernel without `cgroup.kill`) when
     /// the tree won't drain within the bounded sweep, and the process-group
     /// mechanism (macOS/Linux fallback) when a live, non-zombie member rejects
@@ -386,11 +386,11 @@ impl ProcessGroup {
     ///   [`Command::windows_graceful_ctrl_break`](crate::Command::windows_graceful_ctrl_break),
     ///   plus `WM_CLOSE` to every top-level window owned by a live member (an
     ///   Electron app, a desktop tool, a windowed service). This TRIGGERS a clean
-    ///   exit without waiting or escalating. It returns [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) only
+    ///   exit without waiting or escalating. It returns [`crate::ErrorReason::Unsupported`] only
     ///   when the group has **neither** a console-CTRL leader **nor** a windowed
     ///   member (nothing a soft close could reach); every other signal
     ///   ([`Signal::Hup`], [`Signal::Quit`], [`Signal::Usr1`], [`Signal::Usr2`],
-    ///   [`Signal::Other`]) is always [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported).
+    ///   [`Signal::Other`]) is always [`crate::ErrorReason::Unsupported`].
     ///
     /// `SIGKILL` ([`Signal::Kill`], or `Other(libc::SIGKILL)`) is routed through
     /// the same whole-tree hard kill as [`kill_all`](Self::kill_all)
@@ -399,7 +399,7 @@ impl ProcessGroup {
     /// broadcast.
     ///
     /// **Honest send failures (every Unix backend).** A genuinely failed send is
-    /// reported as [`ErrorReason::Io`](crate::ErrorReason::Io), not hidden behind a false `Ok`, and the two POSIX
+    /// reported as [`crate::ErrorReason::Io`], not hidden behind a false `Ok`, and the two POSIX
     /// mechanisms agree on which failures those are:
     /// - an **`EINVAL`** (an out-of-range [`Signal::Other`] number) always surfaces;
     /// - an **`EPERM`** surfaces when it hit a **live, non-zombie** member (a
@@ -426,11 +426,11 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) on Windows for [`Signal::Int`] / [`Signal::Term`]
+    /// [`crate::ErrorReason::Unsupported`] on Windows for [`Signal::Int`] / [`Signal::Term`]
     /// only when the group has no console-CTRL leader and no windowed member (see
     /// Platform support above), and for every other non-[`Kill`](Signal::Kill)
     /// signal unconditionally (a Job Object has no POSIX signals). On **every** Unix
-    /// backend (cgroup and process-group alike), [`ErrorReason::Io`](crate::ErrorReason::Io) if the OS honestly
+    /// backend (cgroup and process-group alike), [`crate::ErrorReason::Io`] if the OS honestly
     /// rejects the send — an `EINVAL` (a bad [`Signal::Other`] number) or an `EPERM`
     /// against a live, non-zombie member (see above); an `ESRCH` (member already
     /// gone) and a harmless zombie-only `EPERM` are not errors. The Windows soft
@@ -445,10 +445,10 @@ impl ProcessGroup {
 
     /// The reach of a **soft stop** on this group *right now* — the honest
     /// capability answer to "if I ask this group to stop gracefully
-    /// ([`signal(Signal::Term)`](Self::signal) / [`Signal::Int`](crate::Signal::Int)),
+    /// ([`signal(Signal::Term)`](Self::signal) / [`Signal::Int`]),
     /// which of its members will actually receive it?" — queried **before** the
     /// attempt so a caller need not fire a `signal`, catch an
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported), and reverse-engineer the
+    /// [`crate::ErrorReason::Unsupported`], and reverse-engineer the
     /// scope.
     ///
     /// The group-axis analogue of
@@ -479,10 +479,10 @@ impl ProcessGroup {
     ///   [`SoftStopScope::Unsupported`] when it holds **neither** (an empty group,
     ///   or plain windowless children with no console opt-in), which is exactly
     ///   when [`signal(Signal::Term)`](Self::signal) would return
-    ///   [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported).
+    ///   [`crate::ErrorReason::Unsupported`].
     ///
     /// This describes the *soft* tier only: the unconditional hard kill
-    /// ([`Signal::Kill`](crate::Signal::Kill), [`kill_all`](Self::kill_all),
+    /// ([`Signal::Kill`], [`kill_all`](Self::kill_all),
     /// dropping the group) always tears the whole tree down regardless of this
     /// value.
     #[cfg(feature = "process-control")]
@@ -542,8 +542,8 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) if the active mechanism cannot freeze the tree;
-    /// otherwise [`ErrorReason::Io`](crate::ErrorReason::Io) if the OS rejects the freeze / `SIGSTOP`.
+    /// [`crate::ErrorReason::Unsupported`] if the active mechanism cannot freeze the tree;
+    /// otherwise [`crate::ErrorReason::Io`] if the OS rejects the freeze / `SIGSTOP`.
     #[cfg(feature = "process-control")]
     pub fn suspend(&self) -> Result<()> {
         self.job
@@ -558,8 +558,8 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) if the active mechanism cannot thaw the tree;
-    /// otherwise [`ErrorReason::Io`](crate::ErrorReason::Io) if the OS rejects the resume / `SIGCONT`.
+    /// [`crate::ErrorReason::Unsupported`] if the active mechanism cannot thaw the tree;
+    /// otherwise [`crate::ErrorReason::Io`] if the OS rejects the resume / `SIGCONT`.
     #[cfg(feature = "process-control")]
     pub fn resume(&self) -> Result<()> {
         self.job
@@ -587,7 +587,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) if the group's membership cannot be read (e.g. a failed
+    /// [`crate::ErrorReason::Io`] if the group's membership cannot be read (e.g. a failed
     /// `cgroup.procs` read or Job Object query).
     #[cfg(feature = "process-control")]
     pub fn members(&self) -> Result<Vec<u32>> {
@@ -638,7 +638,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) only if the group's membership cannot be read (the same
+    /// [`crate::ErrorReason::Io`] only if the group's membership cannot be read (the same
     /// failure as [`members`](Self::members) — a failed `cgroup.procs` read or Job
     /// Object query) or, on Windows, if the process-metadata snapshot cannot be
     /// created at all. A single member vanishing is not an error (it is skipped).
@@ -681,7 +681,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) if the graceful teardown fails — including, when
+    /// [`crate::ErrorReason::Io`] if the graceful teardown fails — including, when
     /// `escalate_to_kill` performs the final hard kill, the same failures as
     /// [`kill_all`](Self::kill_all): the undrained-tree failure on the legacy
     /// pre-5.14 per-pid fallback, and a process-group member that rejects `SIGKILL`
@@ -716,7 +716,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) if the graceful teardown fails (see
+    /// [`crate::ErrorReason::Io`] if the graceful teardown fails (see
     /// [`shutdown`](Self::shutdown) — the same undrained-tree failure on the legacy
     /// per-pid fallback and the process-group live-`EPERM` on the final hard kill
     /// apply).
@@ -796,7 +796,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) if the teardown fails — the same surface as
+    /// [`crate::ErrorReason::Io`] if the teardown fails — the same surface as
     /// [`shutdown`](Self::shutdown): when `escalate` performs the final hard kill,
     /// the undrained-tree failure on the legacy pre-5.14 per-pid fallback and a
     /// process-group member that rejects `SIGKILL` with `EPERM` while still alive. A
@@ -840,7 +840,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io) if the platform's resource query fails.
+    /// [`crate::ErrorReason::Io`] if the platform's resource query fails.
     #[cfg(feature = "stats")]
     pub fn stats(&self) -> Result<ProcessGroupStats> {
         let stats = self.job.stats().map_err(Error::io)?;
@@ -878,7 +878,7 @@ impl ProcessGroup {
     /// written back to `max`). On the **POSIX process-group** mechanism (macOS, the
     /// BSDs, and the Linux fallback with no usable cgroup) there is no whole-tree
     /// cap primitive, so a request carrying **any** cap is refused with
-    /// [`ErrorReason::ResourceLimit`](crate::ErrorReason::ResourceLimit) — never silently dropped — while an all-`None`
+    /// [`crate::ErrorReason::ResourceLimit`] — never silently dropped — while an all-`None`
     /// request (lift every cap) is a trivial success, since the tree is already
     /// unbounded there.
     ///
@@ -894,7 +894,7 @@ impl ProcessGroup {
     ///
     /// # Errors
     ///
-    /// [`ErrorReason::ResourceLimit`](crate::ErrorReason::ResourceLimit) — with [`LimitReason::Invalid`] for a nonsensical
+    /// [`crate::ErrorReason::ResourceLimit`] — with [`LimitReason::Invalid`] for a nonsensical
     /// value (rejected by the shared `validate_limits` before the OS is touched,
     /// exactly as at creation), [`LimitReason::Unsupported`] when the active
     /// mechanism has no whole-tree accounting at all (a process-group mechanism),
@@ -947,7 +947,7 @@ fn program_name(cmd: &Command) -> String {
     cmd.as_std().get_program().to_string_lossy().into_owned()
 }
 
-/// Map a backend `ErrorKind::Unsupported` to the typed [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported),
+/// Map a backend `ErrorKind::Unsupported` to the typed [`crate::ErrorReason::Unsupported`],
 /// passing every other IO failure through unchanged. Unambiguous here: on the
 /// signal/suspend/resume paths the only producer of `Unsupported` is the
 /// backends' own "this platform can't do that" reporting.
@@ -964,7 +964,7 @@ fn map_unsupported(source: std::io::Error, operation: impl Into<String>) -> Erro
 }
 
 /// Reject nonsensical limit values before touching the OS, so a typo surfaces as a
-/// clear [`ErrorReason::ResourceLimit`](crate::ErrorReason::ResourceLimit) (`reason: Invalid`) rather than an opaque
+/// clear [`crate::ErrorReason::ResourceLimit`] (`reason: Invalid`) rather than an opaque
 /// kernel error.
 #[cfg(feature = "limits")]
 fn validate_limits(limits: &ResourceLimits) -> Result<()> {

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -3,7 +3,7 @@
 //!
 //! [`process_info`] answers "does this pid name a process, and what is it?" with
 //! the same best-effort fields a group member carries in a
-//! [`MemberInfo`](crate::MemberInfo); [`process_is_alive`] answers "is the *same*
+//! [`MemberInfo`]; [`process_is_alive`] answers "is the *same*
 //! process I saw earlier still running?" — reuse-safe, by pairing the pid with the
 //! start-time token, so a recycled number is not mistaken for the original.
 //!

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -14,7 +14,7 @@
 //!
 //! Every label value emitted here comes from a **bounded, secret-free** source:
 //! the program *name* (never the full argv), the containment
-//! [`Mechanism`](crate::Mechanism)'s stable identifier, a fixed outcome-class
+//! [`Mechanism`]'s stable identifier, a fixed outcome-class
 //! token, an exit code, or a teardown-phase token. Command **argv** and
 //! **environment values** — which routinely carry secrets — are *never* passed
 //! into this module: the emission functions below do not even take the

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -8,7 +8,7 @@
 //! (rather than instantly via SIGPIPE), and the relay's own I/O is plumbing — a
 //! closed sibling reads as EOF / writes as a broken pipe, neither reported as a
 //! stage's stdin failure. Each stage spawns into its **own** kill-on-drop
-//! [`ProcessGroup`](crate::ProcessGroup) sub-group, so a per-stage
+//! [`ProcessGroup`] sub-group, so a per-stage
 //! [`Command::timeout`] tears down that stage's *whole* subtree (grandchildren of
 //! a forking `sh -c …` included), while a chain-wide
 //! [`Pipeline::timeout`]/teardown fans the kill across every sub-group so the
@@ -307,7 +307,7 @@ impl Pipeline {
     /// - the **last** stage's stdout as it arrives —
     ///   [`stdout_lines`](PipelineSession::stdout_lines) /
     ///   [`events`](PipelineSession::events), with the same
-    ///   consume-once contract as [`RunningProcess`](crate::RunningProcess) (a
+    ///   consume-once contract as [`RunningProcess`] (a
     ///   second take is a loud `Err`, never a silently-empty stream);
     /// - a readiness wait on that stream —
     ///   [`wait_for_line`](PipelineSession::wait_for_line);
@@ -822,7 +822,7 @@ impl Pipeline {
 }
 
 /// A **live streaming session** over a running [`Pipeline`] — the multi-stage
-/// analogue of a [`RunningProcess`](crate::RunningProcess), returned by
+/// analogue of a [`RunningProcess`], returned by
 /// [`Pipeline::start`]. It streams the **last** stage's stdout as it arrives while
 /// every inner stage drains in the background, then folds the same **pipefail**
 /// outcome as the buffering verbs at [`finish`](Self::finish).
@@ -844,7 +844,7 @@ impl Pipeline {
 /// open), the chain-wide [`Pipeline::timeout`] / [`Pipeline::cancel_on`] still
 /// bound the session, and **dropping** the session hard-kills every stage's tree —
 /// the crate's no-orphan invariant holds for a live chain exactly as it does for a
-/// single [`RunningProcess`](crate::RunningProcess). A partially-started chain (one
+/// single [`RunningProcess`]. A partially-started chain (one
 /// stage up, the next failing to spawn) is torn down before [`start`](Pipeline::start)
 /// even returns its error.
 #[must_use = "a PipelineSession streams a live chain; drop it and the whole chain is killed unread"]
@@ -980,7 +980,7 @@ impl PipelineSession {
     /// the culprit is chosen by the same rule as the buffering verbs — the leftmost
     /// checked failure, preferring a genuine failure over a SIGPIPE/teardown victim,
     /// or the last stage when every stage exited cleanly. A chain-wide
-    /// [`Pipeline::timeout`] that elapsed reports [`Outcome::TimedOut`](crate::Outcome::TimedOut)
+    /// [`Pipeline::timeout`] that elapsed reports [`Outcome::TimedOut`]
     /// regardless of how the individual stages were killed, exactly as the buffering
     /// path's whole-chain timeout does.
     ///

--- a/src/pump.rs
+++ b/src/pump.rs
@@ -277,7 +277,8 @@ fn skip_string_escape(bytes: &[u8], from: usize) -> usize {
 ///
 /// Returns [`Cow::Borrowed`] of the **input** line (never of some other `&str`)
 /// on its unchanged fast path, so the caller reuses the already-owned line with
-/// no re-allocation — and, unlike an arbitrary [`CapturePolicy`], that identity
+/// no re-allocation — and, unlike an arbitrary
+/// [`CapturePolicy`](crate::CapturePolicy), that identity
 /// is guaranteed by construction, so no pointer check is needed here (contrast
 /// [`apply_capture_policy`]'s [[K-065]] guard).
 fn strip_vt(line: &str) -> Cow<'_, str> {
@@ -328,7 +329,8 @@ fn strip_vt(line: &str) -> Cow<'_, str> {
 ///
 /// Like [`apply_capture_policy`], this shapes **only** what is retained: the
 /// pump runs it in `emit` *after* the raw-observing handler/tee (which keep
-/// seeing the un-sanitized decoded line, matching the [`CapturePolicy`] boundary,
+/// seeing the un-sanitized decoded line, matching the
+/// [`CapturePolicy`](crate::CapturePolicy) boundary,
 /// see [[K-066]]) and *before* the capture policy — so a secret-scrubbing policy
 /// matches on already-cleaned text, never one where a color escape could hide a
 /// token mid-word (`to\x1b[0mken`). It touches none of the `count`/`seen_bytes`/
@@ -349,7 +351,7 @@ fn apply_vt_sanitize(enabled: bool, line: String) -> String {
     }
 }
 
-/// A shared, bounded line buffer written by a [`pump_lines`] task and read by
+/// A shared, bounded line buffer written by a [`pump_lines_core`] task and read by
 /// the bulk collectors (drain) or the streaming consumer (`next_line`).
 ///
 /// The line counter increments on every line *before* the buffer write, so it

--- a/src/result.rs
+++ b/src/result.rs
@@ -351,7 +351,7 @@ impl<T> ProcessResult<T> {
     /// - [`ErrorReason::Timeout`] if the run was killed by its deadline (checked
     ///   *first*, so a run that both timed out and exited non-zero reports the
     ///   timeout).
-    /// - [`ErrorReason::Signalled`](crate::ErrorReason::Signalled) if it was terminated by a
+    /// - [`ErrorReason::Signalled`] if it was terminated by a
     ///   signal, with no exit code.
     /// - [`ErrorReason::Exit`] for an exit code outside the accepted set, carrying the
     ///   code and both captured streams in full (the

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -27,7 +27,7 @@ use crate::error::Error;
 /// randomness is needed for backoff.
 ///
 /// Distinct from [`RestartPolicy`](crate::RestartPolicy): a `RetryPolicy` **replays
-/// a verb to success** (re-running on a classified [`Error`](crate::Error)), while a
+/// a verb to success** (re-running on a classified [`Error`]), while a
 /// `RestartPolicy` is the [`Supervisor`](crate::Supervisor)'s **keep-alive restart**
 /// schedule for a long-lived process — different subsystems, different intent.
 ///

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -277,7 +277,7 @@ pub trait ProcessRunnerExt: ProcessRunner {
     /// [`timeout`](crate::Command::timeout): a `Some` deadline surfaces as
     /// [`ErrorReason::Timeout`](crate::ErrorReason::Timeout) and tears the process down. On an
     /// **own-group** runner ([`JobRunner`], the default) that teardown covers the
-    /// whole tree; on a **shared** [`ProcessGroup`](crate::ProcessGroup) it reaches
+    /// whole tree; on a **shared** [`ProcessGroup`] it reaches
     /// the run's direct child by pid — a forking child's grandchildren (and, on the
     /// Linux cgroup mechanism, a direct child that catches the graceful signal and
     /// closes stdout but keeps running) may outlive the probe until the group is
@@ -948,7 +948,7 @@ pub(crate) async fn launch(group: &ProcessGroup, command: &Command) -> Result<Ru
     Ok(process)
 }
 
-/// Translate a raw spawn [`Error`] into the crate's launch error, mapping the
+/// Translate a raw spawn [`Error`](crate::Error) into the crate's launch error, mapping the
 /// OS's opaque `NotFound` into [`ErrorReason::NotFound`](crate::ErrorReason::NotFound)
 /// (enriched with the searched dirs for a bare name, or reclassified as
 /// [`ErrorReason::Spawn`](crate::ErrorReason::Spawn) when the program *is* locatable

--- a/src/running/deadline.rs
+++ b/src/running/deadline.rs
@@ -9,7 +9,7 @@
 //! Both sides of the single-word arbiter are funnelled through the two claim
 //! helpers here — [`claim_timed_out`] (a fired deadline) and [`claim_exited`] (a
 //! natural reap) — so the CAS from `TS_PENDING` and its memory ordering live in
-//! one place, and the [`loom_model`] suite can exhaustively check that the two
+//! one place, and the `loom_model` suite can exhaustively check that the two
 //! can never both win.
 
 // The arbiter atomic comes from the crate's `cfg(loom)`-swappable sync layer

--- a/src/running/mod.rs
+++ b/src/running/mod.rs
@@ -691,7 +691,7 @@ impl RunningProcess {
     /// tree.
     ///
     /// `true` — owns a **private** process group; drop hard-kills the whole tree.
-    /// `false` — runs inside a **shared** [`ProcessGroup`](crate::ProcessGroup)
+    /// `false` — runs inside a **shared** [`ProcessGroup`]
     /// whose lifetime the group owns (drop does *not* kill the tree), or a
     /// scripted test double (no OS tree).
     pub fn kills_tree_on_drop(&self) -> bool {
@@ -715,7 +715,7 @@ impl RunningProcess {
     ///
     /// # Errors
     ///
-    /// Returns [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported),
+    /// Returns [`ErrorReason::Unsupported`],
     /// never panicking and never silently ignoring, when the resize cannot apply:
     ///
     /// - the run is **not** a PTY run (no [`use_pty`](crate::Command::use_pty)),
@@ -723,7 +723,7 @@ impl RunningProcess {
     /// - the child has **already exited** — the pseudo-terminal is gone.
     ///
     /// A genuine OS failure of the resize syscall surfaces as
-    /// [`ErrorReason::Io`](crate::ErrorReason::Io).
+    /// [`ErrorReason::Io`].
     ///
     /// The PTY-variant scripted double ([`ScriptedRunner`](crate::testing::ScriptedRunner)
     /// with [`use_pty`](crate::Command::use_pty)) models this hermetically:
@@ -842,7 +842,7 @@ impl RunningProcess {
     ///   [`Command::cancel_on`](crate::Command::cancel_on). Unlike a timeout,
     ///   cancellation is *always* raised (and discards any captured output).
     /// - [`ErrorReason::OutputTooLarge`] — the
-    ///   [`OutputBufferPolicy`](crate::OutputBufferPolicy) is fail-loud
+    ///   [`OutputBufferPolicy`] is fail-loud
     ///   ([`OverflowMode::Error`](crate::OverflowMode)) and the captured output
     ///   exceeded its line or byte ceiling.
     /// - [`ErrorReason::Stdin`] — a configured stdin source failed for a reason other
@@ -1150,7 +1150,7 @@ impl RunningProcess {
     /// awaited.
     ///
     /// Only an **own-group** handle can be shut down here — a **shared-group**
-    /// handle returns [`ErrorReason::Unsupported`](crate::ErrorReason::Unsupported) because
+    /// handle returns [`ErrorReason::Unsupported`] because
     /// shutting it down would tear down the caller's other children too.
     ///
     /// If the configured timeout deadline already elapsed when `shutdown` is

--- a/src/running/probes.rs
+++ b/src/running/probes.rs
@@ -765,6 +765,32 @@ mod tests {
         assert_eq!(finished.outcome, Outcome::Exited(0));
     }
 
+    /// A dialog keeps reading until Enter even when `write_line` must cross the
+    /// scripted duplex capacity. Reading only its first fragment used to close
+    /// stdin before the terminator write and surface `BrokenPipe` to the caller.
+    #[tokio::test]
+    async fn scripted_dialog_reads_a_complete_large_answer_line() {
+        let mut run = ScriptedRunner::new()
+            .fallback(Reply::dialog("answer: ", "accepted> "))
+            .start(&Command::new("quiz").keep_stdin_open())
+            .await
+            .expect("scripted dialog start");
+
+        run.wait_for_output(|tail| tail == "answer: ", Duration::from_secs(5))
+            .await
+            .expect("prompt");
+
+        let answer = "x".repeat(128 * 1024);
+        run.take_stdin()
+            .expect("scripted dialog stdin")
+            .write_line(&answer)
+            .await
+            .expect("the complete answer and Enter are accepted");
+
+        let finished = run.finish().await.expect("finish the dialog");
+        assert_eq!(finished.outcome, crate::Outcome::Exited(0));
+    }
+
     /// A timeout with no matching tail fails with `NotReady` — the same probe
     /// deadline the readiness probes use, never the run's own `Timeout`.
     #[tokio::test(start_paused = true)]

--- a/src/running/probes.rs
+++ b/src/running/probes.rs
@@ -26,8 +26,8 @@ use crate::error::{Error, ErrorReason, Result};
 
 use super::RunningProcess;
 
-/// How often [`RunningProcess::wait_for`] / [`wait_for_port`] /
-/// [`wait_for_socket`] re-check readiness — responsive without
+/// How often [`RunningProcess::wait_for`] / [`RunningProcess::wait_for_port`] /
+/// [`RunningProcess::wait_for_socket`] re-check readiness — responsive without
 /// busy-spinning; matches the 50 ms liveness-poll cadence used elsewhere.
 const READINESS_POLL: Duration = Duration::from_millis(50);
 

--- a/src/running/scripted.rs
+++ b/src/running/scripted.rs
@@ -1,7 +1,7 @@
 //! The scripted backend: canned "child" doubles that feed the same pump
 //! machinery a real [`RealProc`](super::RealProc) does, so hermetic test doubles
 //! exercise the exact code paths a live run does. Only [`crate::doubles`] and
-//! [`crate::cassette`] construct these — they reach in via the narrow surface
+//! `crate::cassette` construct these — they reach in via the narrow surface
 //! re-exported from [`super`] ([`ScriptedProc`], [`ScriptedResultInfo`],
 //! [`split_pump_lines`], and [`RunningProcess::from_scripted`]).
 
@@ -171,11 +171,11 @@ pub(crate) struct ScriptedProc {
     exit_at: Option<tokio::time::Instant>,
     /// Whether this double models a [`use_pty`](crate::Command::use_pty) run, set
     /// by [`from_scripted`](RunningProcess::from_scripted). Gates the hermetic
-    /// [`resize`](Self::resize) model so a non-PTY scripted handle refuses a
+    /// [`RunningProcess::resize_pty`] model so a non-PTY scripted handle refuses a
     /// resize exactly as a real non-PTY one does.
     #[cfg(feature = "pty")]
     pty: bool,
-    /// Every `(cols, rows)` accepted by [`resize`](Self::resize), in call order —
+    /// Every `(cols, rows)` accepted by [`RunningProcess::resize_pty`], in call order —
     /// the hermetic model of a live PTY resize (no real pty). Lets a test observe
     /// that a resize was delivered, and in what geometry.
     #[cfg(feature = "pty")]

--- a/src/running/scripted.rs
+++ b/src/running/scripted.rs
@@ -260,7 +260,7 @@ impl ScriptedProc {
     /// the exchange is deterministic without a paused clock. Aborting the run
     /// (kill/drop) hangs up the feeder like any other scripted child.
     pub(crate) fn new_dialog(prompt: String, response: String, code: i32) -> Self {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
         // stdout: the feeder writes the prompt, waits for stdin, writes the
         // response, then drops its end (EOF). stderr: an immediately-dropped tx
@@ -279,11 +279,15 @@ impl ScriptedProc {
                 return;
             }
             let _ = stdout_tx.flush().await;
-            // 2. Wait for the caller to answer. Any input completes the turn — the
-            //    hermetic model of a child's `read(stdin)` returning; a closed
-            //    stdin (Ok(0)) or error ends the run with no continuation.
-            let mut buf = [0u8; 1024];
-            if let Ok(n) = stdin_read.read(&mut buf).await
+            // 2. Wait for one complete answer line. `ProcessStdin::write_line`
+            //    writes the text and Enter separately, so treating the first
+            //    fragment as the whole answer can close the duplex between those
+            //    writes and race the caller into `BrokenPipe`. EOF after non-empty
+            //    input also completes the answer, like a line reader on a pipe.
+            let mut answer = Vec::new();
+            if let Ok(n) = BufReader::new(&mut stdin_read)
+                .read_until(b'\n', &mut answer)
+                .await
                 && n > 0
             {
                 // 3. Emit the continuation (also flushed).

--- a/src/running/stream.rs
+++ b/src/running/stream.rs
@@ -98,7 +98,7 @@ impl RunningProcess {
     /// when that is a concern. The command's [`timeout`](crate::Command::timeout)
     /// bounds the stream: at the deadline the process tree is killed, pipes close,
     /// and a following
-    /// [`finish`](Self::finish) reports [`Outcome::TimedOut`](crate::Outcome::TimedOut)
+    /// [`finish`](Self::finish) reports [`Outcome::TimedOut`]
     /// even if the child caught the signal and exited cleanly within the grace.
     ///
     /// Returns `Err` instead of a silently-empty stream when stdout was not piped
@@ -308,7 +308,7 @@ impl RunningProcess {
     /// itself is the caller's own responsibility and is not tracked here.
     ///
     /// A run killed by its [`timeout`](crate::Command::timeout) reports
-    /// [`Outcome::TimedOut`](crate::Outcome::TimedOut), even if the child caught
+    /// [`Outcome::TimedOut`], even if the child caught
     /// the signal and exited cleanly within the grace — matching the bulk verbs.
     ///
     /// Designed to pair with `stdout_lines` (consume the stdout stream first),
@@ -561,7 +561,7 @@ pub(super) fn kill_via_weak(group: &Weak<ProcessGroup>, gate: &PidGate) {
 /// hard kill. Windows has no signal tier — hard kill.
 ///
 /// The signal → poll → kill algorithm lives in the shared unix driver
-/// [`crate::sys::graceful::run_pid`], which documents the load-bearing
+/// `crate::sys::graceful::run_pid`, which documents the load-bearing
 /// guarantee: the final `SIGKILL` still fires for a child that caught the
 /// signal, closed stdout, and kept running. To make that guarantee hold when a
 /// streaming consumer drops its handle mid-grace, arm this via

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,4 @@
-//! Diagnostic counters for a [`ProcessGroup`](crate::ProcessGroup), plus the
+//! Diagnostic counters for a [`ProcessGroup`], plus the
 //! time-series samplers ([`StatsSampler`] and its owning `'static` twin
 //! [`OwnedStatsSampler`]) and the per-run profile summary ([`RunProfile`]).
 
@@ -266,7 +266,7 @@ impl tokio_stream::Stream for OwnedStatsSampler {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RunProfile {
-    /// How the run ended — the full [`Outcome`](crate::Outcome), so a profile can
+    /// How the run ended — the full [`Outcome`], so a profile can
     /// distinguish a clean exit from a signal kill from a timeout (all three of
     /// which leave [`code`](Self::code) `None`). Read it directly, or
     /// via the [`code`](Self::code) / [`signal`](Self::signal) /
@@ -303,7 +303,7 @@ impl RunProfile {
     /// [`outcome.code()`](crate::Outcome::code); the method form completes the
     /// `code()` / [`signal()`](Self::signal) / [`timed_out()`](Self::timed_out)
     /// accessor trio that mirrors [`ProcessResult`](crate::ProcessResult) and
-    /// [`Outcome`](crate::Outcome).
+    /// [`Outcome`].
     pub fn code(&self) -> Option<i32> {
         self.outcome.code()
     }

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -7,13 +7,13 @@
 //! question **"keep this alive"**: restart a child whenever it exits (unless its
 //! exit satisfies the policy or a predicate), with bounded restarts and
 //! exponential backoff plus jitter — a minimal `runit`/`systemd`-style keeper on
-//! top of the runner layer. Its [`RestartPolicy`](crate::RestartPolicy) is the
+//! top of the runner layer. Its [`RestartPolicy`] is the
 //! keep-alive twin of that `RetryPolicy`.
 //!
 //! Built entirely on the [`ProcessRunner`] seam, so supervision logic is
 //! hermetically testable with the crate's doubles, and
 //! [`with_runner(&group)`](Supervisor::with_runner) runs every incarnation
-//! inside one shared kill-on-drop [`ProcessGroup`](crate::ProcessGroup).
+//! inside one shared kill-on-drop [`ProcessGroup`].
 
 use std::future::Future;
 use std::pin::Pin;
@@ -297,7 +297,7 @@ pub enum StopReason {
     /// [`GaveUp`](Self::GaveUp) / [`RestartsExhausted`](Self::RestartsExhausted);
     /// either way the number of liveness force-kills is reported in
     /// [`SupervisionOutcome::liveness_kills`], and the final run's
-    /// [`ProcessResult`] carries [`Outcome::Signalled`](crate::Outcome::Signalled).
+    /// [`ProcessResult`] carries [`Outcome::Signalled`].
     Unhealthy,
     /// A caller asked the live [`SupervisionSession`] to stop
     /// ([`SupervisionSession::stop`]): the current incarnation (if any) was
@@ -759,7 +759,7 @@ impl SessionShared {
     }
 }
 
-/// Releases the published live child ([`SessionShared::current`]) when
+/// Releases the published live child ([`SessionState::current`]) when
 /// [`run_to_result`](Supervisor::run_to_result) leaves by **any** path — a
 /// normal return *or* the future being dropped mid-run, which is exactly what a
 /// liveness [`health_check`](Supervisor::health_check) kill does (the losing
@@ -805,7 +805,7 @@ enum Wake {
 /// threshold 5.0 once enabled).
 ///
 /// Runs go through a [`ProcessRunner`] — [`JobRunner`] by default. Override
-/// with [`with_runner`](Self::with_runner) to share a [`ProcessGroup`](crate::ProcessGroup)
+/// with [`with_runner`](Self::with_runner) to share a [`ProcessGroup`]
 /// or inject a test double.
 pub struct Supervisor<R: ProcessRunner = JobRunner> {
     command: Command,

--- a/src/sys/graceful.rs
+++ b/src/sys/graceful.rs
@@ -13,8 +13,8 @@
 //! but the opt-in `windows_graceful_ctrl_break` path (a direct child spawned
 //! `CREATE_NEW_PROCESS_GROUP`) does drive [`run`] with a Job-backed
 //! `GracefulTarget`, so [`run`] and [`GracefulTarget`] are cross-platform. The
-//! single-child kill-and-reap primitives below ([`PidTarget`]/[`run_pid`]/
-//! [`UnixChild`]) lean on `PidGate`/`libc` and stay unix-only.
+//! single-child kill-and-reap primitives below (`PidTarget`/`run_pid`/
+//! `UnixChild`) lean on `PidGate`/`libc` and stay unix-only.
 
 use std::io;
 use std::time::Duration;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -7,7 +7,7 @@
 //! - **Linux** — a [cgroup v2] killed via `cgroup.kill`, falling back to a POSIX
 //!   process group when no writable cgroup is available.
 //! - **macOS / the BSDs** — a POSIX process group (`killpg` the tree on drop);
-//!   no cgroups or Job Objects exist there. See [`pgroup`].
+//!   no cgroups or Job Objects exist there. See `pgroup`.
 //!
 //! Only Unix and Windows are supported; other targets fail to compile (see the
 //! `compile_error!` below).
@@ -62,7 +62,7 @@ pub(crate) struct ProcMetrics {
 /// and Linux uses `/proc/<pid>/stat` field 22 (`starttime`, clock ticks since
 /// boot); the POSIX fallback (macOS/BSD) reports none. This is the per-process
 /// analogue of the pgroup backend's start-time identity token (see
-/// [`pgroup::read_identity`](crate::sys::pgroup)); it exists to keep a pid-reuse
+/// `pgroup::read_identity`); it exists to keep a pid-reuse
 /// race from folding an unrelated process's CPU/memory into a sample.
 #[cfg(feature = "stats")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,7 +115,7 @@ pub(crate) fn process_identity(pid: u32) -> Option<ProcIdentity> {
 /// Identity + best-effort metadata for an **arbitrary** pid (not one tracked by
 /// any group) — the platform-dispatching core of the public
 /// [`process_info`](crate::process_info) query. Returns the same fields a
-/// [`MemberInfo`](crate::MemberInfo) carries for a group member, read through the
+/// [`MemberInfo`] carries for a group member, read through the
 /// **same** per-platform readers (`/proc/<pid>/stat` on Linux, `proc_pidinfo` on
 /// macOS, `Toolhelp32` + creation `FILETIME` on Windows, a `kill(pid, 0)` existence
 /// probe on the bare BSDs).
@@ -211,7 +211,7 @@ pub(crate) struct SpawnOptions {
     pub kill_on_parent_death: bool,
     /// Spawn the child under a pseudo-terminal instead of three independent
     /// pipes (`openpty` on Unix, `CreatePseudoConsole` ConPTY on Windows) — the
-    /// opt-in [`Command::use_pty`](crate::Command::use_pty) mode. Consulted only
+    /// opt-in `Command::use_pty` mode. Consulted only
     /// by the PTY spawn path (`crate::sys::pty`), which is compiled only with the
     /// `pty` feature; without the feature the field is always `false` and the
     /// spawn is byte-identical to the three-pipe path. Containment is unchanged —
@@ -220,8 +220,8 @@ pub(crate) struct SpawnOptions {
     #[cfg_attr(not(feature = "pty"), allow(dead_code))]
     pub use_pty: bool,
     /// The pseudo-terminal window size (`(cols, rows)`) for a `use_pty` spawn, or
-    /// `None` to fall back to the backend default ([`pty::DEFAULT_PTY_SIZE`]).
-    /// Set from [`Command::pty_size`](crate::Command::pty_size). Consulted only by
+    /// `None` to fall back to the backend default (`pty::DEFAULT_PTY_SIZE`).
+    /// Set from `Command::pty_size`. Consulted only by
     /// the PTY spawn path (`crate::sys::pty`, `pty`-feature only) — without
     /// `use_pty` the launch never routes there, so a size configured on a non-PTY
     /// command is a documented no-op (never applied to the three-pipe spawn).
@@ -385,7 +385,7 @@ impl Job {
     /// **Windows soft tier.** When a live member owns a top-level window, or a
     /// direct child was spawned with [`SpawnOptions::windows_new_process_group`]
     /// (via [`Command::windows_graceful_ctrl_break`](crate::Command::windows_graceful_ctrl_break)),
-    /// this drives the *same* shared [`graceful::run`](crate::sys::graceful::run)
+    /// this drives the *same* shared [`graceful::run`]
     /// loop the unix backends use: post `WM_CLOSE` to each member window **and**
     /// `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)` to each console leader, poll
     /// the job's active-process count up to `timeout`, then `TerminateJobObject`

--- a/src/sys/pgroup.rs
+++ b/src/sys/pgroup.rs
@@ -681,7 +681,9 @@ impl Tracked {
     /// the graceful teardown report's before/after member counts must not mutate the
     /// *set* of tracked ids, though it may refresh the `group_seen` latch, which is a
     /// benign monotonic cache). Un-gated: the always-available graceful driver reads
-    /// it through [`ProcessGroup`]'s [`GracefulTarget::alive_count`] as well as the
+    /// it through [`ProcessGroup`]'s
+    /// [`GracefulTarget::alive_count`](crate::sys::graceful::GracefulTarget::alive_count)
+    /// as well as the
     /// `stats`-gated `stats()`.
     fn count_alive(&self) -> usize {
         let mut ids = self.ids.lock().unwrap_or_else(|e| e.into_inner());

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1,5 +1,5 @@
 //! Implementation for unix targets without cgroups or Job Objects (macOS, the
-//! BSDs): a [`ProcessGroup`](super::pgroup::ProcessGroup) per the shared POSIX
+//! BSDs): a [`ProcessGroup`] per the shared POSIX
 //! backend. Every child leads its own process group, so dropping the job
 //! `killpg`s the whole tree — a real kill-on-close guarantee, weaker only
 //! against children that `setsid` away. Surfaced as [`Mechanism::ProcessGroup`].

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -99,7 +99,7 @@ pub(crate) struct Job {
     /// covered by the "kernel kills the tree even on abrupt parent death" headline.
     handle: HANDLE,
     /// Serializes `spawn`'s create-suspended → assign → resume sequence against
-    /// the [`suspend`](Self::suspend)/[`resume`](Self::resume) member-thread
+    /// the `suspend`/`resume` member-thread
     /// walks. Without it, a walk landing between assign and `spawn`'s resume
     /// double-suspends the new child's primary thread (per-thread suspend
     /// *counts*), and `spawn`'s single resume leaves it suspended forever.
@@ -897,7 +897,7 @@ fn ctrl_break_live_leaders(leaders: &[u32], job: HANDLE) -> usize {
 /// Whether a recorded console-CTRL leader `pid` is STILL a live member of `job`
 /// — the recycle-safe predicate the soft-stop paths share so "which leader
 /// counts as reachable" never drifts between the side-effect-free capability
-/// probe ([`Job::soft_stop_scope`](Job::soft_stop_scope)) and the actual
+/// probe (`Job::soft_stop_scope`) and the actual
 /// `GenerateConsoleCtrlEvent` delivery ([`ctrl_break_live_leaders`]).
 ///
 /// A **zero** pid reads false: it is never a real recorded leader, and
@@ -1373,7 +1373,7 @@ fn snapshot_process_metadata() -> io::Result<std::collections::HashMap<u32, (u32
 }
 
 /// The process-creation `FILETIME` of `pid` as its raw
-/// [`MemberInfo`](crate::MemberInfo) start-time token (100-ns units since
+/// [`MemberInfo`] start-time token (100-ns units since
 /// 1601-01-01 UTC), or `None` if the process is gone / unqueryable. Fixed at spawn
 /// and never reused within a boot, so it tells a recycled pid apart from the
 /// original. (The `stats`-gated [`process_identity`] wraps the same read in a
@@ -1462,7 +1462,7 @@ pub(crate) fn process_info(pid: u32) -> io::Result<Option<MemberInfo>> {
 
 /// A FILETIME as its raw 64-bit 100-ns unit count (high/low halves combined).
 /// The process-creation FILETIME serves as the [`ProcIdentity`] anchor (the
-/// `stats` metrics gate) and as the [`MemberInfo`](crate::MemberInfo) start-time
+/// `stats` metrics gate) and as the [`MemberInfo`] start-time
 /// token (the `process-control` snapshot), compared directly in these units;
 /// [`filetime_nanos`] scales the CPU-time FILETIMEs to ns.
 #[cfg(any(feature = "stats", feature = "process-control"))]

--- a/tests/integration/pty.rs
+++ b/tests/integration/pty.rs
@@ -361,14 +361,15 @@ async fn pty_disables_echo_so_a_written_secret_is_not_echoed() {
 async fn pty_size_sets_the_initial_window_and_resize_pty_delivers_a_new_one() {
     use tokio_stream::StreamExt;
 
-    // The child traps `SIGWINCH` FIRST (so a resize can't be missed once the
-    // initial size prints), reports its terminal size, then re-reports on every
-    // resize. `stty size` reads the tty on stdin (the pty slave) and prints
-    // "<rows> <cols>". A loop of short sleeps keeps the shell interruptible so the
+    // The child first removes ProcessKit's initial COLUMNS/LINES environment
+    // defaults: BusyBox `stty size` prefers those immutable values to TIOCGWINSZ,
+    // which would make Alpine report the spawn size forever. It then traps
+    // `SIGWINCH`, reports the actual terminal size from the slave, and re-reports
+    // on every resize. A loop of short sleeps keeps the shell interruptible so the
     // WINCH trap fires promptly; kill-on-drop reaps the whole thing at the end.
     let child = Command::new("sh").args([
         "-c",
-        "trap 'stty size' WINCH; stty size; while :; do sleep 0.2; done",
+        "unset COLUMNS LINES; trap 'sleep 0.1; stty size' WINCH; stty size; while :; do sleep 0.2; done",
     ]);
     let mut proc = JobRunner::new()
         .start(&child.use_pty().pty_size(100, 30))
@@ -394,53 +395,52 @@ async fn pty_size_sets_the_initial_window_and_resize_pty_delivers_a_new_one() {
     );
 
     // Live resize: TIOCSWINSZ updates the master and delivers SIGWINCH, so the
-    // trap re-reports the new geometry "40 120".
+    // trap re-reports the new geometry "40 120". Linux's PTY driver signals the
+    // foreground group immediately before copying the new winsize to both sides;
+    // the short delay in the trap keeps a fast shell on another CPU from querying
+    // the slave inside that kernel-level handoff window.
     //
     // Note: there is a potential scheduling race on CI (especially in Alpine
     // containers under load) between when we read the first size and when the shell
     // has fully entered its interruptible `sleep 0.2` loop. If SIGWINCH is delivered
     // at the wrong moment, the signal might not interrupt the current syscall, and we
     // could read stale output. To harden the test, we defensively poll with multiple
-    // retries: if the first resize doesn't produce new output within a short window,
-    // we issue another resize to ensure the signal is delivered when the shell is
-    // definitely in sleep. We also read multiple lines to be robust to any buffering.
+    // retries. Linux does not send another SIGWINCH when TIOCSWINSZ receives the
+    // already-current geometry, so each retry first nudges to a distinct size before
+    // restoring the requested one. The reader ignores the nudge report and any stale
+    // output until it observes the requested geometry.
     let mut second = None;
     for retry_attempt in 0..3 {
         if retry_attempt > 0 {
-            // If we haven't seen the resized output yet, issue another TIOCSWINSZ.
-            // (This is harmless — resize_pty on an already-resized session just
-            // re-sends the same size and SIGWINCH.)
+            // Force a real geometry transition: repeating 120x40 alone is a no-op
+            // in the Linux tty layer and therefore cannot recover a missed signal.
             tokio::time::sleep(Duration::from_millis(100)).await;
-            proc.resize_pty(120, 40)
-                .expect("live resize retry on a running pty");
-        } else {
-            proc.resize_pty(120, 40)
-                .expect("live resize on a running pty");
+            proc.resize_pty(119, 39)
+                .expect("live resize nudge on a running pty");
         }
+        proc.resize_pty(120, 40)
+            .expect("live resize on a running pty");
 
         // Wait up to 5 seconds per attempt for the resized output. Unlike
         // `completes_within`, a plain `tokio::time::timeout` here returns an
         // `Err` (rather than panicking) when the window elapses, so a slow
         // attempt can be retried instead of failing the whole test outright.
         let found = tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                match lines.next().await {
-                    Some(l) if l.trim().is_empty() => continue,
-                    other => break other,
+            while let Some(line) = lines.next().await {
+                if line.trim() == "40 120" {
+                    return Some(line);
                 }
             }
+            None
         })
         .await;
 
-        match found {
-            Ok(Some(line)) if line.trim() == "40 120" => {
-                second = Some(line);
-                break;
-            }
-            // A stray non-matching line, a closed stream, or a per-attempt
-            // timeout: all fall through to the next retry attempt.
-            Ok(Some(_)) | Ok(None) | Err(_) => {}
+        if let Ok(Some(line)) = found {
+            second = Some(line);
+            break;
         }
+        // A closed stream or a per-attempt timeout falls through to the next
+        // retry. Non-matching lines were consumed inside the attempt.
     }
 
     let second = second.expect("a post-resize size line (after retries)");


### PR DESCRIPTION
## What & why

Doc errors in private items were not caught by CI or Justfile until PR #24 revealed them.

I separated this out from PR #24 because this is a much larger diff, and Claude did essentially all of it.

## Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test` passes (and `cargo test --all-features -- --ignored` if you
      touched spawn / containment / streaming paths)
- (N/A) `CHANGELOG.md` `[Unreleased]` updated when the change is user-facing
      (`Added` / `Changed` / `Fixed`)
- (N/A) Docs updated (rustdoc and the `docs/` guide set) if behavior or API changed
- (N/A) New dependencies carry a "why" comment in `Cargo.toml` (see `CONTRIBUTING.md`)

## Notes for reviewers

I have only done a light review of the changes claude made here.
